### PR TITLE
Add CT-SEG to Datagraph

### DIFF
--- a/imgtools/autopipeline.py
+++ b/imgtools/autopipeline.py
@@ -591,42 +591,15 @@ class AutoPipeline(Pipeline):
                 
                 # Process SEG
                 elif modality == "SEG":
+                    print("***** PROCESSING SEG **********")
                     structure_set = read_results[i]
                     conn_to = output_stream.split("_")[-1]
-                    mask = self.make_binary_mask(structure_set, image, 
-                                                    self.existing_roi_indices, 
-                                                    self.ignore_missing_regex, 
-                                                    roi_select_first=self.roi_select_first, 
-                                                    roi_separate=self.roi_separate)
-                    for name in mask.roi_indices.keys():
-                        if name not in self.existing_roi_indices.keys():
-                            self.existing_roi_indices[name] = len(self.existing_roi_indices)
-                    mask.existing_roi_indices = self.existing_roi_indices
-
-                    
-                    if self.v:
-                        print("mask.GetSize():", mask.GetSize())
-                    mask_arr = np.transpose(sitk.GetArrayFromImage(mask))
-
-                    if len(mask_arr.shape) == 3:
-                        mask_arr = mask_arr.reshape(1, mask_arr.shape[0], mask_arr.shape[1], mask_arr.shape[2])
-                    if self.v:s
-                        print(mask_arr.shape)
-                    roi_names_list = list(mask.roi_indices.keys())
-                    for i in range(mask_arr.shape[0]):
-                        new_mask = sitk.GetImageFromArray(np.transpose(mask_arr[i]))
-                        new_mask.CopyInformation(mask)
-                        new_mask = Segmentation(new_mask)
-                        mask_to_process = new_mask
-                        
-                        # output
-                        self.output(subject_id, mask_to_process, output_stream, True, roi_names_list[i])
-                
+                    #print(read_results[0]))
+                    self.output(subject_id, read_results[i], output_stream)
+                    print("output done")
 
                 metadata[f"output_folder_{colname}"] = pathlib.Path(subject_id, colname).as_posix()
 
-                    
-                
             #Saving all the metadata in multiple text files
             metadata["Modalities"] = str(list(subject_modalities))
             metadata["numRTSTRUCTs"] = num_rtstructs

--- a/imgtools/autopipeline.py
+++ b/imgtools/autopipeline.py
@@ -591,6 +591,7 @@ class AutoPipeline(Pipeline):
                 
                 # Process SEG
                 elif modality == "SEG":
+                    #hi i´m a change
                     print("***** PROCESSING SEG **********")
                     structure_set = read_results[i]
                     conn_to = output_stream.split("_")[-1]

--- a/imgtools/modules/datagraph.py
+++ b/imgtools/modules/datagraph.py
@@ -266,7 +266,7 @@ class DataGraph:
         12) RTDOSE,RTSTRUCT,CT,PT
         '''
         #Basic processing of just one modality
-        supp_mods   = ["RTDOSE", "RTSTRUCT", "CT", "PT", 'MR']
+        supp_mods   = ["RTDOSE", "RTSTRUCT", "CT", "PT", 'MR', 'SEG']
         edge_def    = {"RTSTRUCT,RTDOSE" : 0, "CT,RTDOSE" : 1, "CT,RTSTRUCT" : 2, "PET,RTSTRUCT" : 3, "CT,PT" : 4, 'MR,RTSTRUCT': 2, "RTPLAN,RTSTRUCT": 6, "RTPLAN,RTDOSE": 5, "CT,SEG": 7, "MR,SEG": 7, "MR,RTSTRUCT": 2}
         self.mods   = query_string.split(",")
         self.mods_n = len(self.mods)

--- a/imgtools/modules/segmentation.py
+++ b/imgtools/modules/segmentation.py
@@ -188,6 +188,7 @@ class Segmentation(sitk.Image):
                     res[i, j, k] = max(arr_1[i, j, k], arr_2[i, j, k])
         return res, overlaps
 
+    # the method below can be refactored out of here
     @classmethod
     def from_dicom_seg(cls, mask, meta):
         #get duplicates
@@ -205,6 +206,7 @@ class Segmentation(sitk.Image):
         
         
         frame_groups  = meta.PerFrameFunctionalGroupsSequence
+
         return cls(mask, raw_roi_names=raw_roi_names, frame_groups=frame_groups)
 
         

--- a/imgtools/utils/crawl.py
+++ b/imgtools/utils/crawl.py
@@ -25,7 +25,7 @@ def crawl_one(folder):
                 rel_path  = dcm_path.relative_to(folder_path.parent.parent)                                        # rel_path of dicom from folder
                 rel_posix = rel_path.parent.as_posix()     # folder name + until parent folder of dicom
 
-                meta      = dcmread(dcm, force=True)
+                meta      = dcmread(dcm, force=True, stop_before_pixels=True)
                 patient   = str(meta.PatientID)
                 study     = str(meta.StudyInstanceUID)
                 series    = str(meta.SeriesInstanceUID)


### PR DESCRIPTION
Added code to `datagraph.py` to create edge_type 7 (SEG -> CT) and added support to query them. Currently working on allowing SEGs to be converted to NIFTIs. 

Needs manual testing before automated tests are added. 