### PR TITLE
fix: remove deprecated pydicom.dicomdir.DicomDir variable type option

### DIFF
--- a/src/imgtools/utils/dicomutils.py
+++ b/src/imgtools/utils/dicomutils.py
@@ -59,7 +59,7 @@ def get_modality_metadata(dicom_data, modality: str):
     return metadata
 
 
-def all_modalities_metadata(dicom_data: Union[pydicom.dataset.FileDataset, pydicom.dicomdir.DicomDir]) -> Dict[str, T]:
+def all_modalities_metadata(dicom_data: Union[pydicom.dataset.FileDataset]) -> Dict[str, T]:
     metadata = get_modality_metadata(dicom_data, 'ALL')
     
     if hasattr(dicom_data, 'PixelSpacing') and hasattr(dicom_data, 'SliceThickness'):

--- a/src/imgtools/utils/dicomutils.py
+++ b/src/imgtools/utils/dicomutils.py
@@ -1,5 +1,5 @@
 import pydicom
-from typing import Dict, TypeVar, Union
+from typing import Dict, TypeVar
 import copy
 
 T = TypeVar('T')

--- a/src/imgtools/utils/dicomutils.py
+++ b/src/imgtools/utils/dicomutils.py
@@ -59,7 +59,7 @@ def get_modality_metadata(dicom_data, modality: str):
     return metadata
 
 
-def all_modalities_metadata(dicom_data: Union[pydicom.dataset.FileDataset]) -> Dict[str, T]:
+def all_modalities_metadata(dicom_data: pydicom.dataset.FileDataset) -> Dict[str, T]:
     metadata = get_modality_metadata(dicom_data, 'ALL')
     
     if hasattr(dicom_data, 'PixelSpacing') and hasattr(dicom_data, 'SliceThickness'):


### PR DESCRIPTION
Inclusion of this variable type was causing an error when running latest version of med-imagetools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified input requirements for metadata extraction, now exclusively accepting `FileDataset` instances.

- **Bug Fixes**
	- Clarified handling of modality keys for improved accuracy in metadata extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->