### PR TITLE
fix(datagraph): iteration through edge_types wasnt updated for seg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ simpleitk = "^2.3.1"
 tqdm = "^4.66.4"
 pyyaml = "^6.0.1"
 dill = "^0.3.8"
-attrs = "^23.2.0"
+attrs = ">=23.2.0"
 
 [tool.poetry.scripts]
 autopipeline = "imgtools.autopipeline:main"

--- a/src/imgtools/modules/datagraph.py
+++ b/src/imgtools/modules/datagraph.py
@@ -147,7 +147,7 @@ class DataGraph:
         mr = df[df["modality"] == "MR"]
         pet = df[df["modality"] == "PT"]
 
-        edge_types = np.arange(7)
+        edge_types = np.arange(8)
         for edge in edge_types:
             if edge==0:    # FORMS RTDOSE->RTSTRUCT, can be formed on both series and instance uid
                 df_comb1    = pd.merge(struct, dose, left_on="instance_uid", right_on="reference_rs")
@@ -314,6 +314,23 @@ class DataGraph:
                     #Search for subgraphs with edges 2 or (1 and 0)
                     regex_term = '((?=.*2)|(((?=.*0)|(?=.*5)(?=.*6))(?=.*1)))'
                     final_df = self.graph_query(regex_term, edge_list, "RTDOSE") 
+            elif edge_type==7: # SEG->CT/MR
+                # keep final_df as is
+                final_df = self.df_edges.loc[self.df_edges.edge_type == edge_type].copy()
+                node_dest, node_origin = valid.split(",")
+                final_df.rename(
+                    columns={
+                        "study_x": "study",
+                        "patient_ID_x": "patient_ID",
+                        "series_x": f"series_{node_dest}",
+                        "series_y": f"series_{node_origin}",
+                        "folder_x": f"folder_{node_dest}",
+                        "folder_y": f"folder_{node_origin}",
+                        "subseries_x": f"subseries_{node_dest}",
+                        "subseries_y": f"subseries_{node_origin}",
+                    },
+                    inplace=True,
+                )
             else:
                 final_df = self.df_edges.loc[self.df_edges.edge_type == edge_type, ["study","patient_ID_x", "study_x", "study_y", "series_x","folder_x","series_y","folder_y", "subseries_x", "subseries_y"]]
                 node_dest = valid.split(",")[0]


### PR DESCRIPTION
update edge_types to 8

handle new edge type for SEG->CT/MR mapping in final dataframe processing in parser



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the DataGraph functionality to support an additional edge type, improving the representation of connections between different modalities.
	- Updated logic for edge handling and merging to accommodate the new edge type involving `SEG` and `CT/MR`.

- **Bug Fixes**
	- Corrected edge type handling in query processing to ensure accurate relationships in the resulting data.

- **Chores**
	- Updated package version to 1.5.7 and adjusted the dependency for `attrs` to allow broader version compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->