### PR TITLE
fix: rounding error in resample function

### DIFF
--- a/src/imgtools/ops/functional.py
+++ b/src/imgtools/ops/functional.py
@@ -80,7 +80,7 @@ def resample(
         new_spacing = np.where(spacing == 0, original_spacing, spacing)
 
     if not output_size:
-        new_size = np.floor(original_size * original_spacing / new_spacing).astype(int)
+        new_size = np.round(original_size * original_spacing / new_spacing, decimals=0).astype(int)
     else:
         new_size = np.asarray(output_size)
 

--- a/src/imgtools/ops/functional.py
+++ b/src/imgtools/ops/functional.py
@@ -165,7 +165,7 @@ def resize(
         anti_alias=anti_alias,
         anti_alias_sigma=anti_alias_sigma,
         interpolation=interpolation,
-        output_size=new_size
+        output_size=new_size.astype(int)
     )
 
 

--- a/src/imgtools/ops/functional.py
+++ b/src/imgtools/ops/functional.py
@@ -165,6 +165,7 @@ def resize(
         anti_alias=anti_alias,
         anti_alias_sigma=anti_alias_sigma,
         interpolation=interpolation,
+        output_size=new_size
     )
 
 

--- a/src/imgtools/ops/functional.py
+++ b/src/imgtools/ops/functional.py
@@ -79,7 +79,7 @@ def resample(
         spacing = np.asarray(spacing)
         new_spacing = np.where(spacing == 0, original_spacing, spacing)
 
-    if not output_size:
+    if output_size is None:
         new_size = np.round(original_size * original_spacing / new_spacing, decimals=0).astype(int)
     else:
         new_size = np.asarray(output_size)


### PR DESCRIPTION
When output_size was not provided to `resample` function, the size was determined based on the spacing but was floored. This would sometimes incorrectly shrink the image size. Changed to use `np.round` instead.

Additionally, added the `output_size` argument to the `resample` call in the `resize` function. The output size is already available in the function as `new_size`, so it doesn't make sense to recalculate it in the `resample` function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved image resampling and resizing functions with more precise rounding and type handling.
	- Enhanced parameter validation to ensure consistent integer conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->