### PR TITLE
fix: mis-handling of string as roi_name for to_segmentation

### DIFF
--- a/src/imgtools/modules/structureset.py
+++ b/src/imgtools/modules/structureset.py
@@ -616,6 +616,9 @@ class StructureSet:
         a single name or are lists of strings).
         """
         labels: dict[str, list] = {}
+        if isinstance(roi_names, str):
+            roi_names = [roi_names]
+
         if not roi_names:
             labels = self._assign_labels(
                 list(self.roi_names), roi_select_first, roi_separate
@@ -676,6 +679,10 @@ class StructureSet:
             for i, (name, label_list) in enumerate(labels.items()):
                 for label in label_list:
                     self.get_mask(reference_image, mask, label, i, continuous)
+                seg_roi_indices[name] = i
+        elif isinstance(roi_names, list):
+            for i, name in enumerate(labels):
+                self.get_mask(reference_image, mask, name, i, continuous)
                 seg_roi_indices[name] = i
 
         mask[mask > 1] = 1

--- a/src/imgtools/modules/structureset.py
+++ b/src/imgtools/modules/structureset.py
@@ -649,8 +649,6 @@ class StructureSet:
                                 matching_names
                             )  # {"GTV": ["GTV1", "GTV2"]}
                     labels[name] = extracted_labels
-        if isinstance(roi_names, str):
-            roi_names = [roi_names]
 
         logger.debug(f"Found {len(labels)} labels", labels=labels)
 

--- a/tests/modules/test_structureset.py
+++ b/tests/modules/test_structureset.py
@@ -213,6 +213,7 @@ def test_rtstruct_to_segmentation(roi_points, metadata) -> None:
 
     assert "GTV" in raw_roi_names
     assert "PTV" in raw_roi_names
+    assert list(seg_images.roi_indices.keys()) == ["GTV", "PTV"]
 
     seg_images2 = structure_set.to_segmentation(
         reference_image=ref_image, roi_names="GTV"
@@ -224,3 +225,7 @@ def test_rtstruct_to_segmentation(roi_points, metadata) -> None:
     assert "PTV" not in seg_images2.raw_roi_names
 
     assert seg_images2.get_label(name="GTV") is not None
+
+    assert list(seg_images2.roi_indices.keys()) == ["GTV"]
+
+    assert repr(seg_images2) == "<Segmentation with ROIs: {'GTV': 1}>"

--- a/tests/modules/test_structureset.py
+++ b/tests/modules/test_structureset.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+import SimpleITK as sitk
 
 from imgtools.modules.structureset import (
     StructureSet,
@@ -12,93 +13,111 @@ from imgtools.modules.structureset import (
 def roi_points():
     """Fixture for mock ROI points."""
     return {
-        'GTV': [np.array([[0, 0, 0], [1, 1, 1]])],
-        'PTV': [np.array([[2, 2, 2], [3, 3, 3]])],
-        'CTV_0': [np.array([[4, 4, 4], [5, 5, 5]])],
-        'CTV_1': [np.array([[6, 6, 6], [7, 7, 7]])],
-        'CTV_2': [np.array([[8, 8, 8], [9, 9, 9]])],
-        'ExtraROI': [np.array([[10, 10, 10], [11, 11, 11]])],
+        "GTV": [np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])],
+        "PTV": [np.array([[2.0, 2.0, 2.0], [3.0, 3.0, 3.0]])],
+        "CTV_0": [np.array([[4.0, 4.0, 4.0], [5.0, 5.0, 5.0]])],
+        "CTV_1": [np.array([[6.0, 6.0, 6.0], [7.0, 7.0, 7.0]])],
+        "CTV_2": [np.array([[8.0, 8.0, 8.0], [9.0, 9.0, 9.0]])],
+        "ExtraROI": [np.array([[10.0, 10.0, 10.0], [11.0, 11.0, 11.0]])],
     }
 
 
 @pytest.fixture
 def metadata():
     """Fixture for mock metadata."""
-    return {'PatientName': 'John Doe'}
+    return {"PatientName": "John Doe"}
 
 
 # Parametrized tests for simple and moderately complex cases
 @pytest.mark.parametrize(
-    'names, roi_select_first, roi_separate, expected',
+    "names, roi_select_first, roi_separate, expected",
     [
         # Case 1: Default behavior with exact matches
-        (['GTV', 'PTV'], False, False, {'GTV': 0, 'PTV': 1}),
+        (["GTV", "PTV"], False, False, {"GTV": 0, "PTV": 1}),
         # Case 2: Regex matching
-        (['GTV', 'P.*'], False, False, {'GTV': 0, 'PTV': 1}),
+        (["GTV", "P.*"], False, False, {"GTV": 0, "PTV": 1}),
         # Case 3: Select only the first match for each pattern
-        (['G.*', 'P.*'], True, False, {'GTV': 0, 'PTV': 1}),
+        (["G.*", "P.*"], True, False, {"GTV": 0, "PTV": 1}),
         # Case 4: Separate matches for regex pattern
-        (['P.*'], False, True, {'PTV': 0}),
+        (["P.*"], False, True, {"PTV": 0}),
         # Case 5: Regex pattern with multiple matches (consolidated labels)
-        (['CTV.*'], False, False, {'CTV_0': 0, 'CTV_1': 0, 'CTV_2': 0}),
+        (["CTV.*"], False, False, {"CTV_0": 0, "CTV_1": 0, "CTV_2": 0}),
         # Case 6: Regex pattern with multiple matches (separate labels)
-        (['CTV.*'], False, True, {'CTV_0': 0, 'CTV_1': 0, 'CTV_2': 0}),
+        (["CTV.*"], False, True, {"CTV_0": 0, "CTV_1": 0, "CTV_2": 0}),
         # Case 7: Grouped patterns
         (
-            [['GTV', 'PTV'], 'CTV.*'],
+            [["GTV", "PTV"], "CTV.*"],
             False,
             False,
-            {'GTV': 0, 'PTV': 0, 'CTV_0': 1, 'CTV_1': 1, 'CTV_2': 1},
+            {"GTV": 0, "PTV": 0, "CTV_0": 1, "CTV_1": 1, "CTV_2": 1},
         ),
         # Case 8: Grouped patterns with separate labels for regex matches
         # ([["GTV", "PTV"], "CTV.*"], False, True, {"GTV": 0, "PTV": 0, "CTV_0": 1, "CTV_1": 2, "CTV_2": 3}),
     ],
 )
-def test_assign_labels(names, roi_select_first, roi_separate, expected, roi_points) -> None:
+def test_assign_labels(
+    names, roi_select_first, roi_separate, expected, roi_points
+) -> None:
     """Test _assign_labels method with various cases."""
     structure_set = StructureSet(roi_points)
-    result = structure_set._assign_labels(names, roi_select_first, roi_separate)
+    result = structure_set._assign_labels(
+        names, roi_select_first, roi_separate
+    )
     assert result == expected
 
 
 # Parametrized tests for complex scenarios with intricate patterns
 @pytest.mark.parametrize(
-    'names, roi_select_first, roi_separate, expected',
+    "names, roi_select_first, roi_separate, expected",
     [
         # Case 1: Complex regex patterns with partial matches
         (
-            ['G.*', 'C.*1', 'Extra.*'],
+            ["G.*", "C.*1", "Extra.*"],
             False,
             False,
-            {'GTV': 0, 'CTV_1': 1, 'ExtraROI': 2},
+            {"GTV": 0, "CTV_1": 1, "ExtraROI": 2},
         ),
         # Case 2: Nested regex patterns with grouped and separated labels
         (
-            [['GTV', 'CTV.*'], 'P.*', 'Extra.*'],
+            [["GTV", "CTV.*"], "P.*", "Extra.*"],
             False,
             False,
-            {'GTV': 0, 'CTV_0': 0, 'CTV_1': 0, 'CTV_2': 0, 'PTV': 1, 'ExtraROI': 2},
+            {
+                "GTV": 0,
+                "CTV_0": 0,
+                "CTV_1": 0,
+                "CTV_2": 0,
+                "PTV": 1,
+                "ExtraROI": 2,
+            },
         ),
         # ([["GTV", "CTV.*"], "P.*", "Extra.*"], False, True, {"GTV": 0, "CTV_0_0": 1, "CTV_1_1": 2, "CTV_2_2": 3, "PTV": 4, "ExtraROI": 5}),
         # Case 3: Regex patterns that match all ROIs
         (
-            ['.*'],
+            [".*"],
             False,
             False,
-            {'GTV': 0, 'PTV': 0, 'CTV_0': 0, 'CTV_1': 0, 'CTV_2': 0, 'ExtraROI': 0},
+            {
+                "GTV": 0,
+                "PTV": 0,
+                "CTV_0": 0,
+                "CTV_1": 0,
+                "CTV_2": 0,
+                "ExtraROI": 0,
+            },
         ),
         # ([".*"], False, True, {"GTV_0": 0, "PTV_1": 1, "CTV_0_2": 2, "CTV_1_3": 3, "CTV_2_4": 4, "ExtraROI_5": 5}),
         # Case 4: Overlapping regex patterns
         (
-            ['G.*', 'C.*', 'Extra.*'],
+            ["G.*", "C.*", "Extra.*"],
             False,
             False,
-            {'GTV': 0, 'CTV_0': 1, 'CTV_1': 1, 'CTV_2': 1, 'ExtraROI': 2},
+            {"GTV": 0, "CTV_0": 1, "CTV_1": 1, "CTV_2": 1, "ExtraROI": 2},
         ),
         # (["G.*", "C.*", "Extra.*"], False, True, {"GTV": 0, "CTV_0_0": 1, "CTV_1_1": 2, "CTV_2_2": 3, "ExtraROI_3": 4}),
         # Case 5: No matches for given patterns
         pytest.param(
-            ['NonExistent.*'],
+            ["NonExistent.*"],
             False,
             False,
             {},
@@ -108,10 +127,14 @@ def test_assign_labels(names, roi_select_first, roi_separate, expected, roi_poin
         # pytest.param(["G.*"], True, True, None, marks=pytest.mark.xfail(raises=ValueError)),
     ],
 )
-def test_assign_labels_complex(names, roi_select_first, roi_separate, expected, roi_points) -> None:
+def test_assign_labels_complex(
+    names, roi_select_first, roi_separate, expected, roi_points
+) -> None:
     """Test _assign_labels method with complex scenarios."""
     structure_set = StructureSet(roi_points)
-    result = structure_set._assign_labels(names, roi_select_first, roi_separate)
+    result = structure_set._assign_labels(
+        names, roi_select_first, roi_separate
+    )
     assert result == expected
 
 
@@ -128,7 +151,9 @@ def test_assign_labels_invalid(roi_points) -> None:
         ValueError,
         match="The options 'roi_select_first' and 'roi_separate' cannot both be True.",
     ):
-        structure_set._assign_labels(['G.*'], roi_select_first=True, roi_separate=True)
+        structure_set._assign_labels(
+            ["G.*"], roi_select_first=True, roi_separate=True
+        )
 
 
 def test_init(roi_points, metadata) -> None:
@@ -142,27 +167,60 @@ def test_init(roi_points, metadata) -> None:
     assert structure_set_no_metadata.metadata == {}
 
 
-@patch('imgtools.modules.structureset.dcmread')
+@patch("imgtools.modules.structureset.dcmread")
 def test_from_dicom_rtstruct(mock_dcmread) -> None:
     """Test from_dicom_rtstruct method with mocked DICOM file."""
     """Test from_dicom_rtstruct method with mocked DICOM file."""
     mock_rtstruct = MagicMock()
     mock_rtstruct.StructureSetROISequence = [
-        MagicMock(ROIName='GTV'),
-        MagicMock(ROIName='PTV'),
+        MagicMock(ROIName="GTV"),
+        MagicMock(ROIName="PTV"),
     ]
     mock_rtstruct.ROIContourSequence = [
         MagicMock(),
         MagicMock(),
     ]
-    mock_rtstruct.ROIContourSequence[0].ContourSequence = [MagicMock(ContourData=[1.0, 2.0, 3.0])]
-    mock_rtstruct.ROIContourSequence[1].ContourSequence = [MagicMock(ContourData=[4.0, 5.0, 6.0])]
-    mock_rtstruct.Modality = 'RTSTRUCT'
+    mock_rtstruct.ROIContourSequence[0].ContourSequence = [
+        MagicMock(ContourData=[1.0, 2.0, 3.0])
+    ]
+    mock_rtstruct.ROIContourSequence[1].ContourSequence = [
+        MagicMock(ContourData=[4.0, 5.0, 6.0])
+    ]
+    mock_rtstruct.Modality = "RTSTRUCT"
     mock_dcmread.return_value = mock_rtstruct
 
-    structure_set = StructureSet.from_dicom_rtstruct('dummy')
+    structure_set = StructureSet.from_dicom_rtstruct("dummy")
     # Assert the results
-    assert 'GTV' in structure_set.roi_points
-    assert 'PTV' in structure_set.roi_points
-    assert len(structure_set.roi_points['GTV']) == 1
-    assert len(structure_set.roi_points['PTV']) == 1
+    assert "GTV" in structure_set.roi_points
+    assert "PTV" in structure_set.roi_points
+    assert len(structure_set.roi_points["GTV"]) == 1
+    assert len(structure_set.roi_points["PTV"]) == 1
+
+
+def test_rtstruct_to_segmentation(roi_points, metadata) -> None:
+    """Test rtstruct_to_segmentation method with mocked ROI points."""
+    structure_set = StructureSet(roi_points, metadata)
+    # reference sitk_image
+    ref_image = sitk.Image(10, 10, 10, sitk.sitkFloat32)
+
+    seg_images = structure_set.to_segmentation(
+        reference_image=ref_image, roi_names=["GTV", "PTV"]
+    )
+
+    assert seg_images is not None
+
+    raw_roi_names = seg_images.raw_roi_names
+
+    assert "GTV" in raw_roi_names
+    assert "PTV" in raw_roi_names
+
+    seg_images2 = structure_set.to_segmentation(
+        reference_image=ref_image, roi_names="GTV"
+    )
+
+    assert seg_images2 is not None
+
+    assert "GTV" in seg_images2.raw_roi_names
+    assert "PTV" not in seg_images2.raw_roi_names
+
+    assert seg_images2.get_label(name="GTV") is not None


### PR DESCRIPTION
Remove unnecessary conversion of `roi_names` from string to list and fix handling when a string is passed to the `to_segmentation` function.

fixes #205 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced input handling for ROI names in the segmentation process.
	- Improved flexibility by allowing both string and list input types for ROI names.
- **New Features**
	- Added new test cases to validate the functionality of converting ROI points to segmentation images.
- **Bug Fixes**
	- Updated test data structures for consistency and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->