### PR TITLE
feat: add desired_size to centroid bounding box generation

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -8472,8 +8472,8 @@ packages:
   timestamp: 1733255681319
 - pypi: .
   name: med-imagetools
-  version: 1.21.1
-  sha256: ac108aa50e31005425813068aee54a452d86c76411879110af0ca02842d78265
+  version: 1.22.0
+  sha256: 741d7aaee9d5299f24791dff7e2369bb40b817f375765fd3fdf0941652ca927a
   requires_dist:
   - structlog>=24.0,<25
   - click>=8.1,<9

--- a/src/imgtools/coretypes/box.py
+++ b/src/imgtools/coretypes/box.py
@@ -108,7 +108,7 @@ class RegionBox:
         return cls(Coordinate3D(*coordmin), Coordinate3D(*coordmax))
 
     @classmethod
-    def from_mask_centroid(cls, mask: sitk.Image, label: int = 1) -> RegionBox:
+    def from_mask_centroid(cls, mask: sitk.Image, label: int = 1, desired_size: int | None = None) -> RegionBox:
         """Creates a RegionBox from the centroid of a mask image.
 
         Parameters
@@ -117,6 +117,8 @@ class RegionBox:
             The input mask image.
         label : int, optional
             label in the mask image to calculate the centroid.
+        desired_size : int | None, optional
+            The desired size of the box. If None, the minimum size default from `expand_to_min_size` is used.
 
         Returns
         -------
@@ -131,8 +133,9 @@ class RegionBox:
         centroid_idx = mask.TransformPhysicalPointToIndex(centroid)
 
         return RegionBox(
-            Coordinate3D(*centroid_idx), Coordinate3D(*centroid_idx)
-        )
+            Coordinate3D(*centroid_idx), 
+            Coordinate3D(*centroid_idx)
+        ).expand_to_cube(desired_size)
 
     @classmethod
     def from_mask_bbox(cls, mask: sitk.Image, label: int = 1) -> RegionBox:

--- a/src/imgtools/ops/functional.py
+++ b/src/imgtools/ops/functional.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from typing import Optional, Sequence, Tuple, Union, List
+from typing import List, Optional, Sequence, Tuple
 
 import numpy as np
 import SimpleITK as sitk


### PR DESCRIPTION
In old version, bounding box was a single voxel. Now is expanded to at least the minimum dimension default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Now, users can optionally specify a desired size when generating image bounding boxes for enhanced control.
  
- **Chores**
  - Updated the software version from 1.21.1 to 1.22.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->