### PR TITLE
feat: add function to handle out of bounds coordinates for a RegionBox in an image

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -8472,8 +8472,8 @@ packages:
   timestamp: 1733255681319
 - pypi: .
   name: med-imagetools
-  version: 1.23.0
-  sha256: 233b4cf9ad93489deac92bc63e41abe1cb9483b6c08c1d5875f5153d512232a7
+  version: 1.23.1
+  sha256: b2e49fce8d050d66537e5c5cc6dcce79dc75d6f6fb4d1c689303691eec30318b
   requires_dist:
   - structlog>=24.0,<25
   - click>=8.1,<9

--- a/src/imgtools/coretypes/box.py
+++ b/src/imgtools/coretypes/box.py
@@ -313,6 +313,21 @@ class RegionBox:
                 setattr(min_coord, axis, 0)
                 setattr(max_coord, axis, getattr(max_coord, axis) + diff)
 
+
+    def check_out_of_bounds_coordinates(self, image: sitk.Image) -> None:
+        """Adjust the coordinates to ensure that the max values are not greater than the image size."""
+        # if any of the max values are greater than the image size, set them to the image size,
+        # and subtract the difference from the min values
+        for idx, axis in enumerate(["x", "y", "z"]):
+            max_value = getattr(self.max, axis)
+            image_size = image.GetSize()[idx]
+            if max_value > image_size:
+                logger.debug(f"Adjusting box {axis} coordinates to be within the image size.")
+                diff = max_value - image_size
+                setattr(self.min, axis, getattr(self.min, axis) - diff)
+                setattr(self.max, axis, image_size)
+    
+
     def crop_image(self, image: sitk.Image) -> sitk.Image:
         """Crop an image to the coordinates defined by the box.
 
@@ -327,17 +342,12 @@ class RegionBox:
             The cropped image.
         """
         try:
+            self.check_out_of_bounds_coordinates(image)
             cropped_image = sitk.RegionOfInterest(image, self.size, self.min)
-        except RuntimeError as e:
-            msg = (
-                f"The box {self} is outside"
-                f" the image size {calculate_image_boundaries(image)} "
-            )
-            # this is probably due to the box being outside the image
-            # try to crop the image to the largest possible region
-            # we could handle this in the future, for now let it raise the error
-            # and make user try again with an adjusted box
-            raise BoundingBoxOutsideImageError(msg) from e
+        except Exception as e:
+            msg = f"Error cropping image to the box: {e}"
+            logger.exception(msg)
+            raise e
         else:
             return cropped_image
 

--- a/src/imgtools/coretypes/box.py
+++ b/src/imgtools/coretypes/box.py
@@ -390,6 +390,9 @@ class RegionBox:
             f")"
         )
 
+    def copy(self) -> RegionBox:
+        """Create a copy of the RegionBox."""
+        return RegionBox(self.min, self.max)
 
 if __name__ == "__main__":  # pragma: no cover
     from rich import print  # noqa

--- a/tests/coretypes/test_box.py
+++ b/tests/coretypes/test_box.py
@@ -1,0 +1,139 @@
+import pytest
+from rich import print as rprint
+import SimpleITK as sitk
+from imgtools.coretypes import RegionBox, Coordinate3D, Size3D, BoxPadMethod
+from imgtools.coretypes.box import BoundingBoxOutsideImageError
+from imgtools.datasets import example_data
+# Simple tests
+def test_regionbox_initialization():
+    min_coord = Coordinate3D(0, 0, 0)
+    max_coord = Coordinate3D(10, 10, 10)
+    box = RegionBox(min_coord, max_coord)
+    assert box.min == min_coord
+    assert box.max == max_coord
+    assert box.size == Size3D(10, 10, 10)
+
+def test_regionbox_invalid_initialization():
+    min_coord = Coordinate3D(10, 10, 10)
+    max_coord = Coordinate3D(0, 0, 0)
+    with pytest.raises(ValueError):
+        RegionBox(min_coord, max_coord)
+
+def test_regionbox_from_tuple():
+    box = RegionBox.from_tuple((0, 0, 0), (10, 10, 10))
+    assert box.min == Coordinate3D(0, 0, 0)
+    assert box.max == Coordinate3D(10, 10, 10)
+    assert box.size == Size3D(10, 10, 10)
+
+def test_regionbox_pad_symmetric():
+    box = RegionBox(Coordinate3D(5, 5, 5), Coordinate3D(10, 10, 10))
+    padded_box = box.pad(5)
+    assert padded_box.min == Coordinate3D(0, 0, 0)
+    assert padded_box.max == Coordinate3D(15, 15, 15)
+    assert padded_box.size == Size3D(15, 15, 15)
+
+def test_regionbox_pad_end():
+    box = RegionBox(Coordinate3D(5, 5, 5), Coordinate3D(10, 10, 10))
+    padded_box = box.pad(5, method=BoxPadMethod.END)
+    assert padded_box.min == Coordinate3D(5, 5, 5)
+    assert padded_box.max == Coordinate3D(15, 15, 15)
+    assert padded_box.size == Size3D(10, 10, 10)
+
+def test_regionbox_expand_to_cube():
+    box = RegionBox(Coordinate3D(5, 5, 5), Coordinate3D(10, 10, 10))
+    cube_box = box.expand_to_cube(15)
+    assert cube_box.size == Size3D(15, 15, 15)
+
+def test_regionbox_expand_to_min_size():
+    box = RegionBox(Coordinate3D(5, 5, 5), Coordinate3D(15, 15, 15))
+    min_size_box = box.expand_to_min_size(20)
+    assert min_size_box.size == Size3D(20, 20, 20)
+
+def test_regionbox_crop_image():
+    image = sitk.Image(100, 100, 100, sitk.sitkInt16)
+    box = RegionBox(Coordinate3D(10, 10, 10), Coordinate3D(20, 20, 20))
+    cropped_image = box.crop_image(image)
+    assert cropped_image.GetSize() == (10, 10, 10)
+
+def test_regionbox_crop_image_outside():
+    image = sitk.Image(100, 100, 100, sitk.sitkInt16)
+    box = RegionBox(Coordinate3D(90, 90, 90), Coordinate3D(110, 110, 110))
+    cropped = box.crop_image(image)
+
+    assert cropped.GetSize() == (20, 20, 20)
+
+def test_regionbox_crop_image_and_mask():
+    image = sitk.Image(100, 100, 100, sitk.sitkInt16)
+    mask = sitk.Image(100, 100, 100, sitk.sitkUInt8)
+    box = RegionBox(Coordinate3D(10, 10, 10), Coordinate3D(20, 20, 20))
+    cropped_image, cropped_mask = box.crop_image_and_mask(image, mask)
+    assert cropped_image.GetSize() == (10, 10, 10)
+    assert cropped_mask.GetSize() == (10, 10, 10)
+
+# Edge cases
+
+def test_regionbox_from_centroid_odd_cube():
+
+    mask = example_data()['mask']
+    bbox = RegionBox.from_mask_centroid(mask, 1, 5)
+    expected = RegionBox(
+        Coordinate3D(47, 26, 73),
+        Coordinate3D(52, 31, 78)
+    )
+
+    assert bbox.min == expected.min
+    assert bbox.max == expected.max
+    assert bbox.size == expected.size
+
+def test_bbox_cubed()->None:
+    mask = example_data()['mask']
+    region = RegionBox(
+        Coordinate3D(12, 13, 14),
+        Coordinate3D(21, 23, 25)
+    )
+
+    expanded_region = region.expand_to_cube(13)
+
+    expected = RegionBox(
+        Coordinate3D(10, 11, 13),
+        Coordinate3D(23, 24, 26)
+    )
+
+    assert expanded_region.min == expected.min
+    assert expanded_region.max == expected.max
+    assert expanded_region.size == expected.size
+
+
+def test_adjust_max()->None:
+
+    region = RegionBox(
+        Coordinate3D(12, 13, 14),
+        Coordinate3D(21, 23, 25)
+    )
+    
+    #save a copy to compare size after
+    region_copy = region.copy()
+    
+    image = sitk.Image(20, 20, 20, sitk.sitkInt16)
+
+    region.check_out_of_bounds_coordinates(
+        image=image
+    )
+
+    assert region.size == region_copy.size
+
+
+    expected_min = Coordinate3D(11, 10, 9)
+    expected_max = Coordinate3D(20, 20, 20)
+
+    assert region.min == expected_min
+    assert region.max == expected_max
+
+def test_expand_cube_smaller_size()->None:
+    
+    region = RegionBox(
+        Coordinate3D(12, 13, 14),
+        Coordinate3D(200, 23, 25)
+    )
+    with pytest.raises(ValueError):
+        expanded_region = region.expand_to_cube(10)


### PR DESCRIPTION
This works the same way as `_adjust_negative_coordinates`, but requires the image as an addition input and modifies the RegionBox object directly. 

A message is logged in the debugger if a dimension is adjusted.

I also updated the `crop_image` function to call this before applying the crop.