### PR TITLE
feat: Enhance CLI organization with groups, add shell-completion

### DIFF
--- a/docs/cli/shell-completion.md
+++ b/docs/cli/shell-completion.md
@@ -1,0 +1,109 @@
+# Shell Completion
+
+Shell completion is a feature that allows you to press the `Tab` key while typing a command to automatically complete command names, options, and arguments. This can significantly improve your productivity when working with the `imgtools` CLI.
+
+## Generating Completion Scripts
+
+The `imgtools` CLI provides a built-in command to generate shell completion scripts for various shells:
+
+```bash
+imgtools shell-completion [SHELL]
+```
+
+Where `[SHELL]` is one of: `bash`, `zsh`, or `fish`.
+
+## Installation Instructions
+
+=== "Bash"
+
+    To enable completion for the current bash session:
+
+    ```bash
+    source <(imgtools shell-completion bash)
+    ```
+
+    For permanent setup, add the completion script to a file in your bash completion directory:
+
+    ```bash
+    # Create the completions directory if it doesn't exist
+    mkdir -p ~/.bash_completion.d
+    
+    # Save the completion script to a file
+    imgtools shell-completion bash > ~/.bash_completion.d/imgtools
+    
+    # Add the following to your ~/.bashrc file
+    echo 'source ~/.bash_completion.d/imgtools' >> ~/.bashrc
+    
+    # Reload your shell configuration
+    source ~/.bashrc
+    ```
+
+=== "Zsh"
+
+    To enable completion for the current zsh session:
+
+    ```zsh
+    source <(imgtools shell-completion zsh)
+    ```
+
+    For permanent setup:
+
+    ```zsh
+    # Create the completions directory if it doesn't exist
+    mkdir -p ~/.zsh/completion
+    
+    # Save the completion script to a file
+    imgtools shell-completion zsh > ~/.zsh/completion/_imgtools
+    
+    # Add to your ~/.zshrc file
+    echo 'fpath=(~/.zsh/completion $fpath)' >> ~/.zshrc
+    echo 'autoload -U compinit && compinit' >> ~/.zshrc
+    
+    # Reload your shell configuration
+    source ~/.zshrc
+    ```
+
+=== "Fish"
+
+    To enable completion for the current fish session:
+
+    ```fish
+    imgtools shell-completion fish | source
+    ```
+
+    For permanent setup:
+
+    ```fish
+    # Create the completions directory if it doesn't exist
+    mkdir -p ~/.config/fish/completions
+    
+    # Save the completion script
+    imgtools shell-completion fish > ~/.config/fish/completions/imgtools.fish
+    
+    # Fish will automatically load the completions on next shell start
+    ```
+
+## Verifying Completion Works
+
+After setting up completion, you can verify it works by typing:
+
+```bash
+imgtools <TAB>
+```
+
+This should display available subcommands. You can also try:
+
+```bash
+imgtools dicomsort --<TAB>
+```
+
+This should show the `--`options available for the `dicomsort` command 
+(i.e `--action`, `--output`, etc.)
+
+## Troubleshooting
+
+If completions don't work after following these steps:
+
+1. Make sure you've reloaded your shell configuration or started a new terminal session
+2. Verify that the completion script was properly generated and saved
+3. Check if your shell supports tab completion (it should by default)

--- a/pixi.lock
+++ b/pixi.lock
@@ -10143,8 +10143,8 @@ packages:
   timestamp: 1733255681319
 - pypi: .
   name: med-imagetools
-  version: 2.0.0rc8
-  sha256: 88a4e3b14bd0f3243a5f33191bc4016a06a60bc89392fafb27ab4430fc290c8c
+  version: 2.0.0rc9
+  sha256: 52357da440682efc5b78f8421ae82bee488167bb856a6b3246ee87d34bb59e77
   requires_dist:
   - structlog>=24.0,<25
   - click>=8.1,<9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,16 +61,13 @@ torch = ["torch", "torchio"] # dont think these are even used anymore
 pyvis = ["pyvis>=0.3.2,<0.4"]
 hdf5 = ["h5py>=3.11.0"]
 nrrd = ["pynrrd>=1.0.0"]
-test = [
-  "pygithub>=2.5.0",
-  "aiohttp>=3.8.1",
-]
+test = ["pygithub>=2.5.0", "aiohttp>=3.8.1"]
 all = [
   "pygithub>=2.5.0",
   "aiohttp>=3.8.1",
   "h5py>=3.11.0",
   "pynrrd>=1.0.0",
-  "pyvis>=0.3.2,<0.4"
+  "pyvis>=0.3.2,<0.4",
 ]
 
 # Entry points for CLI commands
@@ -88,12 +85,7 @@ directory = "dist"
 [tool.hatch.build.targets.wheel]
 # Automatically discovers packages in `src/`
 packages = ["src/imgtools"]
-include = [
-    "pyproject.toml",
-    "README.md",
-    "src/imgtools/py.typed",
-    "src/**"
-]
+include = ["pyproject.toml", "README.md", "src/imgtools/py.typed", "src/**"]
 
 [tool.semantic_release]
 version_variables = ["src/imgtools/__init__.py:__version__"]

--- a/src/imgtools/cli/__main__.py
+++ b/src/imgtools/cli/__main__.py
@@ -1,16 +1,62 @@
+"""Command-line interface for the med-imagetools package.
+
+This module sets up the command-line interface (CLI) for the med-imagetools package
+using Click. The CLI is organized into command groups that are registered with a
+CommandRegistry and displayed in organized sections using SectionedGroup.
+
+How to use this system:
+1. To add a new command group:
+   - Use registry.create_group("group-name", "Group description")
+
+2. To add a new command to an existing group:
+   - Implement your command as a Click command function
+   - Register it with registry.add("group-name", your_command)
+
+3. Command implementation pattern:
+   - Define your command using @click.command() and appropriate Click options
+   - Register it in the appropriate section in this file
+
+Example of adding a new command:
+    
+    @click.command()
+    @click.argument("input_path")
+    @click.option("--output", "-o", help="Output file")
+    def my_command(input_path, output):
+        '''My command description.'''
+        # Command implementation here
+        pass
+    
+    # Then register it
+    registry.create_group("my-tools", "My custom tools")
+    registry.add("my-tools", my_command)
+"""
+
 import click
 
 from imgtools import __version__
 
 from . import set_log_verbosity
+from .command_registry import CommandRegistry
 from .dicomfind import dicomfind
 from .dicomsort import dicomsort
-from .testdatasets import is_testdata_available
+from .sectioned_group import SectionedGroup
+from .testdatasets import is_testdata_available, testdata
+
+# Create a shared registry
+registry = CommandRegistry()
+
+# Register groups and commands
+registry.create_group("dicom-tools", "Tools for working with DICOM files.")
+registry.add("dicom-tools", dicomfind)
+registry.add("dicom-tools", dicomsort)
+
+if is_testdata_available():
+    from .testdatasets import testdata
+    registry.create_group("testing", "Datasets for testing and tutorials.")
+    registry.add("testing", testdata)
 
 
-@click.group(
-    no_args_is_help=True,
-)
+@click.group(cls=SectionedGroup, registry=registry, no_args_is_help=True)
 @set_log_verbosity()
 @click.version_option(
     version=__version__,
@@ -18,22 +64,54 @@ from .testdatasets import is_testdata_available
     prog_name="imgtools",
     message="%(package)s:%(prog)s:%(version)s",
 )
-@click.help_option(
-    "-h",
-    "--help",
-)
+@click.help_option("-h", "--help")
 def cli(verbose: int, quiet: bool) -> None:
     """A collection of tools for working with medical imaging data."""
+    # Notes
+    # -----
+    # This function serves as the main entry point for the command-line interface.
+    # It configures logging verbosity and sets up the command groups.
+    
+    # For developers: To extend this CLI, register your commands with the registry
+    # object using the pattern shown in this file.
     pass
 
+cli.add_registry(registry)
 
-cli.add_command(dicomsort)
-cli.add_command(dicomfind)
+@click.command(name="shell-completion", hidden=True)
+@click.argument("shell", type=click.Choice(["bash", "zsh", "fish"]))
+@click.pass_context
+def shell_completion(ctx: click.Context, shell: str) -> None:
+    """Emit shell completion script (hidden command).
+    
+    This command generates a shell completion script for the specified shell.
+    Supported shells: bash, zsh, fish.
+    """
+    # validate the shell argument
+    if shell not in ["bash", "zsh", "fish"]:
+        raise click.BadParameter(f"Unsupported shell: {shell}. Supported: bash, zsh, fish")
 
-if is_testdata_available():
-    from .testdatasets import testdata
+    # Generate the completion script
+    command = ["_IMGTOOLS_COMPLETE={}_source imgtools".format(shell)]
+    import subprocess
 
-    cli.add_command(testdata)
+    # Generate the completion script using subprocess
+    try:
+        result = subprocess.run(
+            command,
+            shell=True,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        click.echo(result.stdout)
+    except subprocess.CalledProcessError as e:
+        click.echo(f"Error generating completion script: {e}", err=True)
+    except Exception as e:
+        click.echo(f"Unexpected error: {e}", err=True)
+    
+
+cli.add_command(shell_completion)
 
 if __name__ == "__main__":
     cli()

--- a/src/imgtools/cli/command_registry.py
+++ b/src/imgtools/cli/command_registry.py
@@ -1,0 +1,151 @@
+"""Registry system for organizing CLI commands into logical groups.
+
+This module provides the infrastructure for organizing Click commands into
+named groups with descriptions, which improves the organization and readability
+of CLI help output.
+"""
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Optional
+
+import click
+
+Command = click.Command
+
+@dataclass
+class CommandGroup:
+    """Represents a command group with an optional description.
+    
+    A CommandGroup organizes related commands together under a single named
+    section in the CLI help output.
+    
+    Parameters
+    ----------
+    name : str
+        The name of the command group.
+    description : str, optional
+        A brief description of the command group's purpose.
+    commands : list[Command], optional
+        A list of Click commands belonging to this group.
+        
+    Notes
+    -----
+    Developers should not create CommandGroup instances directly.
+    Instead, use CommandRegistry.create_group() to create new command groups.
+    """
+    name: str
+    description: Optional[str] = None
+    commands: list[Command] = field(default_factory=list)
+
+@dataclass
+class CommandRegistry:
+    """Registry mapping section name to command groups.
+    
+    This class manages command groups and provides methods to create groups
+    and add commands to those groups. It centralizes command organization
+    for the CLI.
+    
+    Parameters
+    ----------
+    _groups : dict, optional
+        Internal dictionary mapping group names to CommandGroup objects.
+        
+    Notes
+    -----
+    Developers should use this class as follows:
+    
+    1. Create a registry instance:
+       ```python
+       registry = CommandRegistry()
+       ```
+       
+    2. Define command groups:
+       ```python
+       registry.create_group("my-tools", "Tools for my specific purpose")
+       ```
+       
+    3. Add commands to groups:
+       ```python
+       # where my_command is a Click command function
+       registry.add("my-tools", my_command)
+       ```
+       
+    4. Use with SectionedGroup:
+       ```python
+       @click.group(cls=SectionedGroup, registry=registry)
+       def cli():
+           '''CLI description'''
+           pass
+           
+       cli.add_registry(registry)
+       ```
+    """
+    _groups: dict[str, CommandGroup] = field(default_factory=dict)
+
+    def create_group(self, name: str, description: Optional[str] = None) -> None:
+        """Create a new command group with optional description.
+        
+        Parameters
+        ----------
+        name : str
+            The name of the group to create.
+        description : str, optional
+            A brief description of the group's purpose.
+            
+        Raises
+        ------
+        ValueError
+            If a group with the given name already exists.
+            
+        Examples
+        --------
+        >>> registry = CommandRegistry()
+        >>> registry.create_group("conversion", "File conversion utilities")
+        """
+        if name in self._groups:
+            raise ValueError(f"Group '{name}' already exists")
+        self._groups[name] = CommandGroup(name=name, description=description)
+
+    def add(self, group: str, cmd: Command) -> None:
+        """Add a command to an existing group.
+        
+        Parameters
+        ----------
+        group : str
+            The name of the group to add the command to.
+        cmd : Command
+            The Click command to add to the group.
+            
+        Raises
+        ------
+        ValueError
+            If the specified group does not exist.
+            
+        Examples
+        --------
+        >>> @click.command()
+        >>> def convert_file(filepath):
+        >>>     '''Convert a file.'''
+        >>>     pass
+        >>> 
+        >>> registry.add("conversion", convert_file)
+        """
+        if group not in self._groups:
+            raise ValueError(f"Group '{group}' does not exist. Create it first using create_group()")
+        self._groups[group].commands.append(cmd)
+
+    def groups(self) -> dict[str, CommandGroup]:
+        """Return all command groups.
+        
+        Returns
+        -------
+        dict
+            Dictionary mapping group names to CommandGroup objects.
+            
+        Notes
+        -----
+        This method is primarily used internally by SectionedGroup to format
+        help output, but can be useful for inspecting the current registry state.
+        """
+        return self._groups

--- a/src/imgtools/cli/sectioned_group.py
+++ b/src/imgtools/cli/sectioned_group.py
@@ -1,0 +1,118 @@
+# sectioned_group.py
+
+from __future__ import annotations
+
+from click import Group, Command
+from typing import TYPE_CHECKING
+from .command_registry import CommandRegistry
+
+if TYPE_CHECKING:
+    from click import Context, HelpFormatter
+
+class SectionedGroup(Group):
+    """A Click Group that supports subcommand groupings via a CommandRegistry.
+    
+    This class extends Click's Group to provide organized command sections in the 
+    help output. Commands are grouped into named sections with descriptions, 
+    making the CLI help more organized and user-friendly.
+    
+    Parameters
+    ----------
+    *args
+        Arguments to pass to the Click Group constructor.
+    registry : CommandRegistry, optional
+        Registry containing command groups and their commands.
+    **kwargs
+        Keyword arguments to pass to the Click Group constructor.
+        
+    Notes
+    -----
+    Developers should not typically need to instantiate this class directly.
+    Instead, use it as the `cls` parameter when creating a Click group:
+    
+    ```python
+    @click.group(cls=SectionedGroup, registry=my_registry)
+    def cli():
+        '''CLI description'''
+        pass
+    ```
+    
+    Then register commands via the registry and add them with:
+    
+    ```python
+    cli.add_registry(my_registry)
+    ```
+    """
+
+    def __init__(self, *args, registry: CommandRegistry | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._registry = registry or CommandRegistry()
+
+    def add_registry(self, registry: CommandRegistry) -> None:
+        """Assign a registry and register all commands from it.
+        
+        This method associates a CommandRegistry with this group and adds all
+        commands from the registry to the Click group.
+        
+        Parameters
+        ----------
+        registry : CommandRegistry
+            The registry containing command groups to add to this Click group.
+            
+        Notes
+        -----
+        This should be called after defining the main CLI function and all
+        commands have been registered with the registry.
+        """
+        self._registry = registry
+        for group in registry.groups().values():
+            for cmd in group.commands:
+                self.add_command(cmd)
+
+    def format_commands(self, ctx: Context, formatter: HelpFormatter) -> None:
+        """Format commands into sectioned groups in the help output.
+        
+        Overrides the default help formatter to display commands organized by
+        their groups with group descriptions as section headers.
+        
+        Parameters
+        ----------
+        ctx : Context
+            The Click context.
+        formatter : HelpFormatter
+            The formatter to write to.
+            
+        Notes
+        -----
+        This method is called automatically by Click when generating help text.
+        Developers don't need to call this method directly.
+        """
+        if not self._registry.groups():
+            # No groups to display
+            return
+        
+        # print out a header
+        formatter.write_paragraph()
+        formatter.write(f"{'':>{formatter.current_indent}}AVAILABLE COMMANDS:\n")
+
+
+        for group in self._registry.groups().values():
+            if not group.commands: # Skip empty groups
+                continue
+            rows = []
+            limit = formatter.width - 6 - max(len(cmd.name) for cmd in group.commands)
+            for cmd in group.commands:
+                rows.append((cmd.name, cmd.get_short_help_str(limit)))
+            
+            # what to write in the section heading
+            heading : str
+            if group.description:
+                heading = f"[{group.name.upper()}] {group.description}"
+            else:
+                heading = group.name
+            heading_str = f"{'':>{formatter.current_indent}}{heading}\n"            
+            formatter.write_paragraph()
+            formatter.write(heading_str)
+            formatter.indent()
+            formatter.write_dl(rows)
+            formatter.dedent()


### PR DESCRIPTION
Implement a `SectionedGroup` for better organization of CLI commands and add documentation for shell completion in the `imgtools` CLI.

<details><summary>screenshots</summary>
<p>
![image](https://github.com/user-attachments/assets/589733c5-1d78-4164-a72d-a60f47da0c1c)

![image](https://github.com/user-attachments/assets/aa516430-3a3d-4335-884a-f241dfaf53dc)

![image](https://github.com/user-attachments/assets/8c99df8c-e204-407a-b2b7-7741d2c2f52a)

</p>
</details> 

- **New Features**
  - Launched an organized command-line interface for med-imagetools.
  - Introduced a “dicom-tools” group with commands to find and sort DICOM images, along with an optional testing group.
  - Added a hidden command to generate shell completion scripts for bash, zsh, and fish.

- **Refactor**
  - Streamlined the command grouping and help output for a clearer and more extensible user experience.
