### PR TITLE
feat(dicom_metadata): add additional date and time fields to ModalityMetadataExtractor

### DIFF
--- a/src/imgtools/dicom/dicom_metadata/extractor_base.py
+++ b/src/imgtools/dicom/dicom_metadata/extractor_base.py
@@ -134,10 +134,19 @@ class ModalityMetadataExtractor(ABC):
         "ScanProgressionDirection",
         "ScanOptions",
         "AcquisitionNumber",
+        "ProtocolName",
+        # Date Time Information
+        "StudyDate",
+        "StudyTime",
+        "SeriesDate",
+        "SeriesTime",
+        "ContentDate",
+        "ContentTime",
         "AcquisitionDateTime",
         "AcquisitionDate",
         "AcquisitionTime",
-        "ProtocolName",
+        "InstanceCreationDate",
+        "InstanceCreationTime",
     }
 
     @classmethod


### PR DESCRIPTION
Enhance the ModalityMetadataExtractor by including extra date and time fields for improved metadata extraction.

```
        # Date Time Information
        "StudyDate",
        "StudyTime",
        "SeriesDate",
        "SeriesTime",
        "ContentDate",
        "ContentTime",
        "AcquisitionDateTime",
        "AcquisitionDate",
        "AcquisitionTime",
        "InstanceCreationDate",
        "InstanceCreationTime",
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced DICOM metadata extraction to include additional date and time details for studies, series, and image content.
  - Updated the extraction process to now capture instance creation information, offering more precise metadata over previous protocol details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->