### PR TITLE
feat: simplify index.csv created by crawler

### DIFF
--- a/docs/images/Declan_UML.drawio
+++ b/docs/images/Declan_UML.drawio
@@ -1,0 +1,10 @@
+<mxfile host="65bd71144e">
+    <diagram id="W7sAdYrgC83sTiVH-Z2u" name="Page-1">
+        <mxGraphModel dx="1334" dy="749" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/src/imgtools/cli/interlacer.py
+++ b/src/imgtools/cli/interlacer.py
@@ -59,7 +59,7 @@ def interlacer(path: Path,
     if (path.is_file() and force):
         logger.warning(f"force requires a directory as input. {path} will be used as the index.")
     
-    if (path.is_file() and n_jobs > 1):
+    if (path.is_file() and n_jobs != DEFAULT_WORKERS):
         logger.warning(f"n_jobs requires a directory as input. {path} will be used as the index.")
 
     elif (path.is_dir()):

--- a/tests/integration/cli/test_interlacer_cli.py
+++ b/tests/integration/cli/test_interlacer_cli.py
@@ -51,6 +51,7 @@ def test_interlacer_collections(
     result = runner.invoke(interlacer_cli, [
         str(input_dir),
         "--n-jobs", "1",
+        "--force"
     ])
 
     assert result.exit_code == 0, f"{collection} failed: {result.exception}\n {result.exc_info}"

--- a/tests/integration/dicom/test_interlacer.py
+++ b/tests/integration/dicom/test_interlacer.py
@@ -100,4 +100,11 @@ def test_interlacer_visualize(medimage_by_collection, caplog) -> None:
 
         assert viz_path.exists()
 
+        index_duplicates = crawler.index
+        index_duplicates.loc[len(index_duplicates)] = index_duplicates.loc[0]
+
+        with pytest.raises(Exception, match="The input file contains duplicate rows."):
+            interlacer = Interlacer(crawler.index)
+
+
         break


### PR DESCRIPTION
Crawler currently creates the index.csv with potential duplicates (same SeriesInstanceUID, different subseries)
not a big deal, but can make it very confusing seeing multiple rows there. This pull request implements changes to fix [Issue #361](https://github.com/bhklab/med-imagetools/issues/361).


- Added duplicate dropping functionality into `parse_dicom_dir`. The function will now delete rows which contain the same metadata, ignoring subseries. 
- `Interlacer` now raises a `DuplicateRowError` when the `index.csv` file contains duplicate entries (again ignoring subseries).
- Updated `test_interlacer.py` to ensure that the `DuplicateRowError` is thrown when there are duplicate rows. 
- Updated `test_interlacer_cli.py` to always recrawl the test directory to remove duplicate rows that may be in the existing index files prior to testing. This ensures no `DuplicateRowError` is thrown during this test. 

