### PR TITLE
feat: 351 imgtools dicomshow cli entry point

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -11241,8 +11241,8 @@ packages:
   timestamp: 1733255681319
 - pypi: .
   name: med-imagetools
-  version: 2.3.0
-  sha256: 26a476984f8bba32141a77ada3fb11c1f8726491d282fed5ae8f10afd42d75ee
+  version: 2.4.0
+  sha256: fa689710f6a4ef8feefb36db0ef727f8fc88baa52888a94b84c1ab2365888d60
   requires_dist:
   - structlog>=25.0,<26
   - click>=8.1,<9

--- a/src/imgtools/cli/__main__.py
+++ b/src/imgtools/cli/__main__.py
@@ -38,6 +38,7 @@ from imgtools import __version__
 from . import set_log_verbosity
 from .autopipeline import autopipeline
 from .dicomfind import dicomfind
+from .dicomshow import dicomshow
 from .dicomsort import dicomsort
 from .index import index
 from .interlacer import interlacer
@@ -59,6 +60,7 @@ registry.add('core commands', nnunet_pipeline)
 registry.create_group("utilities", "Tools for working with DICOM files.")
 registry.add("utilities", dicomfind)
 registry.add("utilities", dicomsort)
+registry.add("utilities", dicomshow)
 
 if not testdata.hidden:
     registry.create_group("testing", "Datasets for testing and tutorials.")

--- a/src/imgtools/cli/dicomshow.py
+++ b/src/imgtools/cli/dicomshow.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import re
+from typing import List
+from rich import print
+from rich.table import Table
+import click
+
+from imgtools.loggers import logger
+
+@click.command(no_args_is_help=True)
+@click.argument(
+    "dicom_file",
+    type=str,
+)
+@click.option(
+    "-m",
+    "--modality",
+    default=None,
+    type=str,
+    show_default=True,
+    help="Optionally specify the modality of the dicom, if modality is not specified it will be automatically determined. ",
+)
+@click.help_option(
+    "-h",
+    "--help",
+)
+def dicomshow(
+    dicom_file: str,
+    modality: str,
+) -> None:
+    """Extracts and displays the metadata associated with a single dicom file."""
+    from pydicom import dcmread
+    from pydicom.dataset import FileDataset
+    import re
+
+    split_input = dicom_file.split("::", 1)
+    file_path = split_input[0]
+    tags = []
+    if len(split_input)>1:
+        parts = split_input[1].split('.')
+        for part in parts:
+            if part[0] == '(':
+                match = re.search(r"\(([0-9A-Fa-f]{4}),\s*([0-9A-Fa-f]{4})\)", part)
+                if match:
+                    tags.append((int(match.group(1), 16), int(match.group(2), 16)))
+            else:
+                tags.append(part.split('[')[0])
+            match = re.search(r'\[(\d+)\]', part)
+            if match:
+                tags.append(int(match.group(1)))
+
+    print(f"[blue]{tags}")
+
+
+    logger.info(f"Extracting tags from {dicom_file}")
+    result = dcmread(file_path, stop_before_pixels=True)
+    table = Table(title=f"[gold1]{dicom_file}", box=None)
+    table.add_column("Keyword", justify="left", style="cyan", no_wrap=True)
+    table.add_column("Value", style="magenta")
+    
+
+    if tags:
+        for tag in tags:
+            if type(tag) is int:
+                result = result[tag]
+                print(f"[red]{result.keys()}\n\n[blue]{result.values()}")
+            else:
+                result = result.get(tag)
+        table.add_row(split_input[1], str(result))
+    else:
+        
+        for key in result.keys():
+            row = result.get(key, default="")
+            tag = row.keyword
+            val = str(row.value)
+            table.add_row(str(tag), val)
+    print(table)
+    logger.info(f"Extraction complete.")
+
+    

--- a/src/imgtools/cli/dicomshow.py
+++ b/src/imgtools/cli/dicomshow.py
@@ -13,14 +13,6 @@ from imgtools.loggers import logger
     "dicom_file",
     type=str,
 )
-@click.option(
-    "-m",
-    "--modality",
-    default=None,
-    type=str,
-    show_default=True,
-    help="Optionally specify the modality of the dicom, if modality is not specified it will be automatically determined. ",
-)
 @click.help_option(
     "-h",
     "--help",


### PR DESCRIPTION
Added a new cli tool `dicomshow` which mimics the functionality of `pydicom show`. The additions in this branch address (issue 351)[https://github.com/bhklab/med-imagetools/issues/351] and renders (issue 350)[https://github.com/bhklab/med-imagetools/issues/350] redundant. The functionality requested in both issues has been combined into one cli command. 

### Usage
```
imgtools dicomshow your_dicom.dcm
```
will print all metadata of `your_dicom.dcm`.

The user can also specify a single tag to be printed like so:
```
imgtools dicomshow your_dicom.dcm::specific_tag
```

This will print the value of `specific_tag` in `your_dicom.dcm`.

This can be taken further if the user wants the value of a tag that is nested within another tag: 

```
imgtools dicomshow your_dicom.dcm::specific_tag.nested_tag
```

This will print the value of `nested_tag` which can be found within the `specific_tag` field of `your_dicom.dcm`.

You can also access individual elements of a list like so: 

```
imgtools dicomshow your_dicom.dcm::specific_tag[0].nested_tag
```

This accesses the first element is `specific_tag` and returns the value of `nested_tag`. 

