### PR TITLE
feat: allow user to query via the CLI #358

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -11241,8 +11241,8 @@ packages:
   timestamp: 1733255681319
 - pypi: .
   name: med-imagetools
-  version: 2.3.0
-  sha256: 26a476984f8bba32141a77ada3fb11c1f8726491d282fed5ae8f10afd42d75ee
+  version: 2.4.0
+  sha256: fa689710f6a4ef8feefb36db0ef727f8fc88baa52888a94b84c1ab2365888d60
   requires_dist:
   - structlog>=25.0,<26
   - click>=8.1,<9

--- a/src/imgtools/cli/__main__.py
+++ b/src/imgtools/cli/__main__.py
@@ -39,6 +39,7 @@ from . import set_log_verbosity
 from .autopipeline import autopipeline
 from .dicomfind import dicomfind
 from .dicomsort import dicomsort
+from .query import query
 from .index import index
 from .interlacer import interlacer
 from .nnunet_pipeline import nnunet_pipeline
@@ -59,6 +60,7 @@ registry.add('core commands', nnunet_pipeline)
 registry.create_group("utilities", "Tools for working with DICOM files.")
 registry.add("utilities", dicomfind)
 registry.add("utilities", dicomsort)
+registry.add("utilities", query)
 
 if not testdata.hidden:
     registry.create_group("testing", "Datasets for testing and tutorials.")

--- a/src/imgtools/cli/query.py
+++ b/src/imgtools/cli/query.py
@@ -1,0 +1,92 @@
+import click
+import os
+from pathlib import Path
+from imgtools.loggers import logger
+
+cpu_count: int | None = os.cpu_count()
+DEFAULT_WORKERS: int = cpu_count - 2 if cpu_count is not None else 1
+
+@click.command(no_args_is_help=True)
+@click.argument(
+    "path",
+    type=click.Path(
+        exists=True, path_type=Path, dir_okay=True, file_okay=True
+    ),
+)
+@click.argument(
+    "query_string",
+    type=str,
+)
+@click.option(
+    "--group-by-root",
+    type=bool,
+    default=True,
+    help="""If True, group the returned SeriesNodes by their root CT/MR/PT
+    node (i.e., avoid duplicate root nodes across results).""",
+)
+@click.option(
+    "--n-jobs",
+    type=int,
+    default=DEFAULT_WORKERS,
+    help="Number of jobs to use for parallel processing.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Force overwrite existing files.",
+)
+@click.help_option("--help", "-h")
+def query(  path: Path,
+            query_string: str,
+            group_by_root: bool,
+            n_jobs: int,
+            force: bool,
+            ) -> None:
+
+    from imgtools.dicom.interlacer import Interlacer, ModalityHighlighter, print_interlacer_tree
+    from rich.console import Console
+
+    if (path.is_file() and force):
+        logger.warning(f"force requires a directory as input. {path} will be used as the index.")
+    
+    if (path.is_file() and n_jobs > DEFAULT_WORKERS):
+        logger.warning(f"n_jobs requires a directory as input. {path} will be used as the index.")
+
+    elif (path.is_dir()):
+        index_path = path.parent / ".imgtools" / path.name / "index.csv"
+        if (force or not index_path.exists()):
+            from imgtools.dicom.crawl import Crawler
+            logger.info("Initializing crawl.")
+            try:
+                crawler = Crawler(
+                    dicom_dir=path,
+                    n_jobs=n_jobs,
+                    force=force,
+                )
+                crawler.crawl()
+            except Exception as e:
+                logger.exception("Failed to crawl directory.")
+                raise click.Abort() from e
+            logger.info("Crawling completed.")
+            logger.info("Crawl results saved to %s", crawler.output_dir)
+        path = index_path
+
+    try:
+        interlacer = Interlacer(path)
+    except Exception as e:
+        logger.exception("Failed to initialize interlacer.")
+        raise click.Abort() from e
+    
+    try:
+        result = interlacer.query(query_string=query_string, group_by_root=group_by_root)
+    except Exception as e:
+        logger.exception("Failed to query interlacer tree.")
+        raise click.Abort() from e
+
+    # Update root node children to reflect query structure instead of overall index structure
+    for group in result:
+        group[0].children = group[1:]
+    root_nodes = [group[0] for group in result]
+
+    print_interlacer_tree(root_nodes, input_directory=None)

--- a/src/imgtools/cli/query.py
+++ b/src/imgtools/cli/query.py
@@ -21,7 +21,7 @@ DEFAULT_WORKERS: int = cpu_count - 2 if cpu_count is not None else 1
     "--group-by-root",
     type=bool,
     default=True,
-    help="""If True, group the returned SeriesNodes by their root CT/MR/PT
+    help="""If True, group the returned dicoms by their root CT/MR/PT
     node (i.e., avoid duplicate root nodes across results).""",
 )
 @click.option(
@@ -81,7 +81,7 @@ def query(  path: Path,
     try:
         result = interlacer.query(query_string=query_string, group_by_root=group_by_root)
     except Exception as e:
-        logger.exception("Failed to query interlacer tree.")
+        logger.exception("Failed to query interlacer forest.")
         raise click.Abort() from e
 
     # Update root node children to reflect query structure instead of overall index structure

--- a/tests/integration/cli/test_query_cli.py
+++ b/tests/integration/cli/test_query_cli.py
@@ -1,0 +1,73 @@
+import pytest
+from pathlib import Path
+from click.testing import CliRunner
+import os
+from imgtools.cli.query import query as query_cli
+import shutil
+
+
+@pytest.fixture(scope="function")
+def runner() -> CliRunner:
+    return CliRunner()
+
+@pytest.fixture(scope="function")
+def collection(request):
+    data_dir = Path("data")
+    
+    value = request.param
+    if not (data_dir / value).exists():
+        yield value
+    else:
+        shutil.copytree(data_dir / value, data_dir / f"{value}-interlacer-test-temp", dirs_exist_ok=True)
+        yield f"{value}-interlacer-test-temp"
+        shutil.rmtree(data_dir / f"{value}-interlacer-test-temp")
+
+
+@pytest.mark.parametrize("collection", [
+    "CPTAC-UCEC",
+    "NSCLC_Radiogenomics",
+    "LIDC-IDRI",
+    "Head-Neck-PET-CT",
+    "HNSCC",
+    "Pancreatic-CT-CBCT-SEG",
+], indirect=True)
+def test_interlacer_collections(
+    runner: CliRunner,
+    medimage_by_collection,
+    collection: str,
+    dataset_type: str,
+):
+    """Test `imgtools query` on each collection from public or private sets."""
+ 
+
+    input_dir = Path("data") / collection
+
+    if not Path(input_dir).exists():
+        pytest.skip(f"Collection {collection} not found {dataset_type=}")
+
+    print(f"Testing {collection} in {input_dir}")
+    out_dir = input_dir.parent / ".imgtools" / collection
+
+    result = runner.invoke(query_cli, [
+        str(input_dir),
+        "CT,RTDOSE",
+        "--n-jobs", "1",
+    ])
+
+    assert result.exit_code == 0, f"{collection} failed: {result.exception}\n {result.exc_info}"
+
+    result = runner.invoke(query_cli, [
+        str(out_dir / "index.csv"),
+        "CT,RTDOSE",
+    ])
+
+    assert result.exit_code == 0, f"{collection} failed: {result.exception}\n {result.exc_info}"
+
+    os.remove(out_dir / "index.csv")
+
+    result = runner.invoke(query_cli, [
+        str(input_dir),
+        "CT,RTDOSE",
+    ])
+
+    assert result.exit_code == 0, f"{collection} failed: {result.exception}\n {result.exc_info}"


### PR DESCRIPTION
Added new cli tool `query` which allows the user to query a dataset for specific modalities. 

# Usage

```
Usage: imgtools query [OPTIONS] PATH QUERY_STRING
```

## Arguments: 

`PATH` - a path to either an index.csv file, or a dicom directory. If PATH is a directory then the directory will be crawled first and an index file will be generated. 

`QUERY_STRING` - a string of comma separated modalities used to query the interlacer forest. 

## Options:
  `--group-by-root` BOOLEAN  If True, group the returned dicoms by their root
                           CT/MR/PT node (i.e., avoid duplicate root nodes
                           across results).

 ` --n-jobs` INTEGER                 Number of jobs to use for parallel processing.

  `--force`                                   Force overwrite existing files.

  `-h`, `--help`                           Show this message and exit.

# Example: 
```
imgtools query ./data/.imgtools/CPTAC-UCEC-interlacer-test-temp/index.csv "MR,RTSTRUCT"
```
Returns:
```
Patients
└── C3L-02403
    ├── MR (Series-97219780)
    │   ├── RTSTRUCT (Series-823546.4)
    │   ├── RTSTRUCT (Series-583914.4)
    │   ├── RTSTRUCT (Series-813582.4)
    │   └── RTSTRUCT (Series-833795.4)
    ├── MR (Series-45733428)
    │   ├── RTSTRUCT (Series-531285.4)
    │   ├── RTSTRUCT (Series-558960.4)
    │   ├── RTSTRUCT (Series-55458746)
    │   └── RTSTRUCT (Series-520374.4)
    └── MR (Series-86646175)
        ├── RTSTRUCT (Series-561186.4)
        ├── RTSTRUCT (Series-624377.4)
        ├── RTSTRUCT (Series-729338.4)
        └── RTSTRUCT (Series-719238.4)
```