### PR TITLE
feat: improve error handling for "failed samples", validate RT Contour Type

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -11305,8 +11305,8 @@ packages:
   timestamp: 1733255681319
 - pypi: ./
   name: med-imagetools
-  version: 2.4.0
-  sha256: fa689710f6a4ef8feefb36db0ef727f8fc88baa52888a94b84c1ab2365888d60
+  version: 2.5.0
+  sha256: 0bbb8aa38277c1c8634eda08b53c12c3f0b9304d8bf9307b2989d352008a7d81
   requires_dist:
   - structlog>=25.0,<26
   - click>=8.1,<9

--- a/pixi.lock
+++ b/pixi.lock
@@ -11305,8 +11305,8 @@ packages:
   timestamp: 1733255681319
 - pypi: ./
   name: med-imagetools
-  version: 2.5.0
-  sha256: 0bbb8aa38277c1c8634eda08b53c12c3f0b9304d8bf9307b2989d352008a7d81
+  version: 2.6.0
+  sha256: 4672c1103002ffcc74191096a6624ada390b7b5bda1cca90a6cef82b49b9ca0e
   requires_dist:
   - structlog>=25.0,<26
   - click>=8.1,<9

--- a/src/imgtools/autopipeline.py
+++ b/src/imgtools/autopipeline.py
@@ -135,7 +135,7 @@ class ProcessSampleResult:
             "processing_time": f"{self.processing_time:.2f}s",
         }
 
-        if self.success:
+        if not self.has_error:
             return {
                 **base_dict,
                 "output_files": [str(f) for f in self.output_files],
@@ -221,12 +221,14 @@ def process_one_sample(
     }
 
     # check if our input samples is a subset of our loaded sample_images
+    # we use subset, because we may have loaded more images than requested (subseries)
     if not series_instance_uids.issubset(loaded_series_instance_uids):
         error_msg = (
             f"Loaded {len(loaded_series_instance_uids)} sample"
             f" images do not match input samples {len(series_instance_uids)}. "
             "This most likely may be due to failures to match ROIs. "
-            f"The {len(sample_images)} will not be processed or saved."
+            f"We will save {len(loaded_series_instance_uids)} loaded, "
+            f"out of {len(series_instance_uids)} input series. "
         )
         result.error_type = "ROIMatchError"
         result.error_message = error_msg
@@ -234,8 +236,6 @@ def process_one_sample(
             "loaded_series": list(loaded_series_instance_uids),
             "input_series": list(series_instance_uids),
         }
-        result.processing_time = time.time() - start_time
-        return result
 
     try:
         transformed_images = transformer(sample_images)
@@ -252,6 +252,10 @@ def process_one_sample(
             SampleNumber=idx,
         )
         result.output_files = list(saved_files)
+        if not result.output_files:
+            raise ValueError(
+                "No output files were saved. Check the output directory."
+            )
         result.success = True
     except Exception as e:
         error_message = str(e)
@@ -430,12 +434,11 @@ class Autopipeline:
                 all_results.append(result)
 
                 # Update progress bar and track results by success/failure
-                if result.success:
+                if not result.has_error:
                     successful_results.append(result)
-                    pbar.update(1)
                 else:
                     failed_results.append(result)
-                    pbar.update(1)
+                pbar.update(1)
 
         # Create pipeline results object
         pipeline_results = PipelineResults(

--- a/src/imgtools/coretypes/masktypes/seg.py
+++ b/src/imgtools/coretypes/masktypes/seg.py
@@ -180,7 +180,11 @@ class SEG:
     metadata: dict[str, Any] = field(default_factory=dict)  # noqa
 
     @classmethod
-    def from_dicom(cls, dicom: DicomInput) -> SEG:  # noqa: PLR0912
+    def from_dicom(  # noqa: PLR0912
+        cls,
+        dicom: DicomInput,
+        metadata: dict[str, Any] | None = None,
+    ) -> SEG:
         """
         Loads a DICOM-SEG object from a DICOM file.
         """
@@ -206,7 +210,7 @@ class SEG:
             )
             raise SegmentationError(msg) from e
 
-        metadata = extract_metadata(ds_seg, "SEG", extra_tags=None)  # type: ignore
+        metadata = metadata or extract_metadata(ds_seg, "SEG", extra_tags=None)  # type: ignore
         segments: dict[int, Segment] = {}
         for segnum in seg.segment_numbers:
             segdesc = seg.get_segment_description(segnum)
@@ -265,7 +269,7 @@ class SEG:
             raw_seg=seg,
             ref_indices=ref_indices,
             segments=segments,
-            metadata=metadata,
+            metadata={k: v for k, v in metadata.items() if v},
         )
 
     @property

--- a/src/imgtools/coretypes/masktypes/structureset.py
+++ b/src/imgtools/coretypes/masktypes/structureset.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "RTStructureSet",
+    "ROIContourExtractionError",
     "ContourPointsAcrossSlicesError",
     "MaskArrayOutOfBoundsError",
     "UnexpectedContourPointsError",
@@ -141,6 +142,59 @@ class NonIntegerZSliceIndexError(Exception):  # pragma: no cover
         )
 
 
+class ROIContourExtractionError(ROIContourError):
+    """Exception raised when extracting ROI contour data fails with details about the specific ROI.
+
+    This exception contains additional information about the ROI index, name,
+    and referenced ROI number to provide context for the error.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        roi_index: int,
+        roi_name: str,
+        referenced_roi_number: int = None,
+        additional_info: dict = None,
+    ) -> None:
+        """Initialize with detailed information about the ROI extraction failure.
+
+        Parameters
+        ----------
+        message : str
+            Base error message describing what went wrong
+        roi_index : int
+            Index of the ROI in the ROIContourSequence
+        roi_name : str
+            Name of the ROI (for context in error messages)
+        referenced_roi_number : int, optional
+            Referenced ROI number from the DICOM file, by default None
+        additional_info : dict, optional
+            Any additional information to include in the error message, by default None
+        """
+        self.roi_index = roi_index
+        self.roi_name = roi_name
+        self.referenced_roi_number = referenced_roi_number or (roi_index + 1)
+        self.additional_info = additional_info or {}
+
+        # Build detailed error message
+        roi_identifier = (
+            f"ROI at index {self.roi_index}, "
+            f"(ReferencedROINumber={self.referenced_roi_number})"
+            f" with name '{self.roi_name}'"
+        )
+        detailed_message = f"{roi_identifier}: {message}"
+
+        # Add any additional info to the message
+        if self.additional_info:
+            details = ", ".join(
+                f"{k}={v}" for k, v in self.additional_info.items()
+            )
+            detailed_message += f" [Additional info: {details}]"
+
+        super().__init__(detailed_message)
+
+
 @dataclass
 class RTStructureSet:
     """Represents the entire structure set, containing multiple ROIs.
@@ -203,6 +257,7 @@ class RTStructureSet:
     def from_dicom(
         cls,
         dicom: DicomInput,
+        metadata: Dict[str, Any] | None = None,
     ) -> RTStructureSet:
         """Create a RTStructureSet object from an RTSTRUCT DICOM file.
 
@@ -217,6 +272,12 @@ class RTStructureSet:
             - If a directory is provided, it will be searched for a single DICOM
             file. If multiple files are found, an error will be raised.
             - If a `FileDataset` object is provided, it will be used directly.
+        metadata : dict[str, Any] | None, optional
+            If provided, this metadata will be used instead of extracting it
+            from the DICOM file. This is useful because our crawler
+            extracts and processes the metadata, possibly doing some better
+            remapping to figure out the correct ReferencedSeriesInstanceUID.
+
         Returns
         -------
         RTStructureSet
@@ -247,18 +308,22 @@ class RTStructureSet:
 
         # logger.debug("Loading RTSTRUCT DICOM file.", dicom=dicom)
         dicom_rt: FileDataset = load_dicom(dicom)
-        metadata: Dict[str, Any] = extract_metadata(
-            dicom_rt, "RTSTRUCT", extra_tags=None
+        metadata: Dict[str, Any] = metadata or extract_metadata(
+            dicom_rt,
+            "RTSTRUCT",
+            extra_tags=None,
         )
         rt = cls(
-            metadata=metadata,
+            metadata={k: v for k, v in metadata.items() if v},
         )
 
         # Extract ROI contour points for each ROI and
         for roi_index, roi_name in enumerate(metadata["ROINames"]):
             try:
                 extracted_roi: Sequence = cls._get_roi_points(
-                    dicom_rt, roi_index=roi_index
+                    dicom_rt,
+                    roi_index=roi_index,
+                    roi_name=roi_name,
                 )
             except ROIContourError as ae:
                 rt.roi_map_errors[roi_name] = ae
@@ -277,7 +342,11 @@ class RTStructureSet:
         return rt
 
     @staticmethod
-    def _get_roi_points(rtstruct: FileDataset, roi_index: int) -> Sequence:
+    def _get_roi_points(
+        rtstruct: FileDataset,
+        roi_index: int,
+        roi_name: str,
+    ) -> Sequence:
         """Extract and reshapes contour points for a specific ROI in an RTSTRUCT file.
         The passed in roi_index is what is used to index the ROIContourSequence,
         whereas the roi_name is mainly used for debugging purposes.
@@ -293,6 +362,8 @@ class RTStructureSet:
             The loaded DICOM RTSTRUCT file.
         roi_index : int
             The index of the ROI in the ROIContourSequence.
+        roi_name : str
+            The name of the ROI, used for debugging and error messages only.
 
         Returns
         -------
@@ -302,7 +373,7 @@ class RTStructureSet:
 
         Raises
         ------
-        ROIContourError
+        ROIContourExtractionError
             If the ROIContourSequence, ContourSequence, or ContourData is
             missing or malformed.
 
@@ -329,40 +400,34 @@ class RTStructureSet:
                 "The DICOM RTSTRUCT file is missing 'ROIContourSequence'."
             )
 
+        # Try to get ROIContour for this ROI
+        roi_contour = rtstruct.ROIContourSequence[roi_index]
+
+        # Set up the error with common info
+        error = ROIContourExtractionError("", roi_index, roi_name)
+
         # Check for ContourSequence in the specified ROI
-        if not hasattr(
-            roi_contour := rtstruct.ROIContourSequence[roi_index],
-            "ContourSequence",
-        ):
-            msg = (
-                f"ROI at index {roi_index}, (ReferencedROINumber={roi_index + 1}) "
-                "is missing 'ContourSequence';"
-            )
-            raise ROIContourError(msg)
+        if not hasattr(roi_contour, "ContourSequence"):
+            error.message = "Missing 'ContourSequence'"
+            raise error
 
         if len(roi_contour.ContourSequence) == 0:
-            msg = (
-                f"ROI at index {roi_index}, (ReferencedROINumber={roi_index + 1}) "
-                "has an empty 'ContourSequence'."
-            )
-            raise ROIContourError(msg)
+            error.message = "Empty 'ContourSequence'"
+            raise error
 
         # Sometimes the contour could be a POINT or just broken
         # and not have a ContourData
         # Check for ContourData in the first contour
         if not hasattr(roi_contour.ContourSequence[0], "ContourData"):
-            msg = f"ContourSequence in ROI at index {roi_index} is missing 'ContourData'. "
-            raise ROIContourError(msg)
-        elif (
-            geometric_type := roi_contour.ContourSequence[
-                0
-            ].ContourGeometricType
-        ) != "CLOSED_PLANAR":
-            msg = (
-                f"ContourSequence in ROI at index {roi_index} has unexpected "
-                f"ContourGeometricType: {geometric_type}. Expected 'CLOSED_PLANAR'."
-            )
-            raise ROIContourError(msg)
+            error.message = "Missing 'ContourData' in ContourSequence"
+            raise error
+
+        # Check geometry type
+        geometric_type = roi_contour.ContourSequence[0].ContourGeometricType
+        if geometric_type != "CLOSED_PLANAR":
+            error.message = f"Unexpected ContourGeometricType: {geometric_type}. Expected 'CLOSED_PLANAR'."
+            error.additional_info = {"geometric_type": geometric_type}
+            raise error
 
         return roi_contour.ContourSequence
 

--- a/src/imgtools/coretypes/masktypes/structureset.py
+++ b/src/imgtools/coretypes/masktypes/structureset.py
@@ -353,6 +353,16 @@ class RTStructureSet:
         if not hasattr(roi_contour.ContourSequence[0], "ContourData"):
             msg = f"ContourSequence in ROI at index {roi_index} is missing 'ContourData'. "
             raise ROIContourError(msg)
+        elif (
+            geometric_type := roi_contour.ContourSequence[
+                0
+            ].ContourGeometricType
+        ) != "CLOSED_PLANAR":
+            msg = (
+                f"ContourSequence in ROI at index {roi_index} has unexpected "
+                f"ContourGeometricType: {geometric_type}. Expected 'CLOSED_PLANAR'."
+            )
+            raise ROIContourError(msg)
 
         return roi_contour.ContourSequence
 
@@ -663,25 +673,31 @@ class RTStructureSet:
 if __name__ == "__main__":  # pragma: no cover
     from rich import print  # noqa
 
-    from imgtools.coretypes.imagetypes import Scan
     from imgtools.coretypes.masktypes.roi_matching import (
         ROIMatcher,
     )
 
-    ct_path = Path("data/RADCURE/RADCURE-0331/Study-03560/CT-3.0")
-    rt_path = Path(
-        "data/RADCURE/RADCURE-0331/Study-03560/RTSTRUCT-1.0/00000001.dcm"
+    # ct_path = Path("data/RADCURE/RADCURE-0331/Study-03560/CT-3.0")
+    # rt_path = Path(
+    #     "data/RADCURE/RADCURE-0331/Study-03560/RTSTRUCT-1.0/00000001.dcm"
+    # )
+
+    # scan = Scan.from_dicom(ct_path.as_posix())
+    # rtstruct = RTStructureSet.from_dicom(rt_path)
+
+    # roi_matcher = ROIMatcher(
+    #     match_map={"ROI": [".*"]},
+    # )
+
+    # vm = rtstruct.get_vector_mask(
+    #     scan,
+    #     roi_matcher,
+    # )
+    # print(vm)  # noqa: T201
+
+    cptac_rt = Path(
+        "data/CPTAC-UCEC/C3L-02403/RTSTRUCT_Series-531285.4/00000001.dcm"
     )
 
-    scan = Scan.from_dicom(ct_path.as_posix())
-    rtstruct = RTStructureSet.from_dicom(rt_path)
-
-    roi_matcher = ROIMatcher(
-        match_map={"ROI": [".*"]},
-    )
-
-    vm = rtstruct.get_vector_mask(
-        scan,
-        roi_matcher,
-    )
-    print(vm)  # noqa: T201
+    rtstruct_cptac = RTStructureSet.from_dicom(cptac_rt)
+    print(rtstruct_cptac.roi_names)  # noqa: T201

--- a/src/imgtools/coretypes/masktypes/structureset.py
+++ b/src/imgtools/coretypes/masktypes/structureset.py
@@ -149,13 +149,19 @@ class ROIContourExtractionError(ROIContourError):
     and referenced ROI number to provide context for the error.
     """
 
+    roi_index: int
+    roi_name: str
+    referenced_roi_number: int | None
+    additional_info: dict | None
+    message: str
+
     def __init__(
         self,
         message: str,
         roi_index: int,
         roi_name: str,
-        referenced_roi_number: int = None,
-        additional_info: dict = None,
+        referenced_roi_number: int | None = None,
+        additional_info: dict | None = None,
     ) -> None:
         """Initialize with detailed information about the ROI extraction failure.
 
@@ -308,7 +314,7 @@ class RTStructureSet:
 
         # logger.debug("Loading RTSTRUCT DICOM file.", dicom=dicom)
         dicom_rt: FileDataset = load_dicom(dicom)
-        metadata: Dict[str, Any] = metadata or extract_metadata(
+        metadata = metadata or extract_metadata(
             dicom_rt,
             "RTSTRUCT",
             extra_tags=None,
@@ -318,7 +324,7 @@ class RTStructureSet:
         )
 
         # Extract ROI contour points for each ROI and
-        for roi_index, roi_name in enumerate(metadata["ROINames"]):
+        for roi_index, roi_name in enumerate(metadata["ROINames"]):  # type: ignore[arg-type]
             try:
                 extracted_roi: Sequence = cls._get_roi_points(
                     dicom_rt,
@@ -334,7 +340,7 @@ class RTStructureSet:
         # tag the logger with the original RTSTRUCT file name
         rt.plogger = logger.bind(
             PatientID=metadata.get("PatientID", "Unknown"),
-            SeriesInstanceUID=metadata.get("SeriesInstanceUID", "Unknown")[
+            SeriesInstanceUID=metadata.get("SeriesInstanceUID", "Unknown")[  # type: ignore[index]
                 -8:
             ],
             filepath=Path(dicom) if isinstance(dicom, (str, Path)) else dicom,

--- a/src/imgtools/coretypes/masktypes/structureset.py
+++ b/src/imgtools/coretypes/masktypes/structureset.py
@@ -174,11 +174,11 @@ class RTStructureSet:
         init=False,
     )
     roi_map: dict[str, Sequence] = field(
-        repr=False,
         default_factory=dict,
     )
     roi_map_errors: dict[str, ROIContourError] = field(
-        repr=False, default_factory=dict, init=False
+        default_factory=dict,
+        init=False,
     )
 
     # store a hidden cache to store the numpy arrays
@@ -673,31 +673,25 @@ class RTStructureSet:
 if __name__ == "__main__":  # pragma: no cover
     from rich import print  # noqa
 
-    from imgtools.coretypes.masktypes.roi_matching import (
-        ROIMatcher,
-    )
+    cptac = {
+        "mr": Path("data/CPTAC-UCEC/C3L-02403/MR_Series-45733428.4/"),
+        "rt_seed": Path(
+            "data/CPTAC-UCEC/C3L-02403/RTSTRUCT_Series-558960.4/00000001.dcm"
+        ),
+        "rt_contour2": Path(
+            "data/CPTAC-UCEC/C3L-02403/RTSTRUCT_Series-520374.4/00000001.dcm"
+        ),
+        "rt_contour": Path(
+            "data/CPTAC-UCEC/C3L-02403/RTSTRUCT_Series-55458746/00000001.dcm"
+        ),
+    }
 
-    # ct_path = Path("data/RADCURE/RADCURE-0331/Study-03560/CT-3.0")
-    # rt_path = Path(
-    #     "data/RADCURE/RADCURE-0331/Study-03560/RTSTRUCT-1.0/00000001.dcm"
-    # )
+    rt_seed = RTStructureSet.from_dicom(cptac["rt_seed"])
+    print("[red]THIS SHOULD HAVE ERRORS[/red]")
+    print(rt_seed)
 
-    # scan = Scan.from_dicom(ct_path.as_posix())
-    # rtstruct = RTStructureSet.from_dicom(rt_path)
-
-    # roi_matcher = ROIMatcher(
-    #     match_map={"ROI": [".*"]},
-    # )
-
-    # vm = rtstruct.get_vector_mask(
-    #     scan,
-    #     roi_matcher,
-    # )
-    # print(vm)  # noqa: T201
-
-    cptac_rt = Path(
-        "data/CPTAC-UCEC/C3L-02403/RTSTRUCT_Series-531285.4/00000001.dcm"
-    )
-
-    rtstruct_cptac = RTStructureSet.from_dicom(cptac_rt)
-    print(rtstruct_cptac.roi_names)  # noqa: T201
+    rt_contour = RTStructureSet.from_dicom(cptac["rt_contour"])
+    rt_contour2 = RTStructureSet.from_dicom(cptac["rt_contour2"])
+    print("[green]THESE SHOULD NOT HAVE ERRORS[/green]")
+    print(rt_contour)
+    print(rt_contour2)

--- a/src/imgtools/dicom/crawl/crawler.py
+++ b/src/imgtools/dicom/crawl/crawler.py
@@ -73,6 +73,16 @@ class Crawler:
             raise CrawlResultsNotAvailableError("crawl_results")
         return self._crawl_results
 
+    def get_series_info(self, series_uid: str) -> dict[str, str]:
+        """Get the series information for a given series UID."""
+        if series_uid not in self.crawl_results.crawl_db_raw:
+            msg = f"Series UID {series_uid} not found in crawl results."
+            raise ValueError(msg)
+
+        data = self.crawl_results.crawl_db_raw[series_uid]
+        first_subseries = next(iter(data.values()))
+        return first_subseries
+
     def get_folder(self, series_uid: str) -> str:
         """Get the folder for a given series UID."""
         if series_uid not in self.crawl_results.crawl_db_raw:

--- a/src/imgtools/io/sample_input.py
+++ b/src/imgtools/io/sample_input.py
@@ -486,6 +486,9 @@ class SampleInput(BaseModel):
         series: SeriesNode,
     ) -> MedImage | VectorMask | None:
         """Load a non-reference image series based on modality."""
+        series_info = self.crawler.get_series_info(
+            series_uid=series.SeriesInstanceUID
+        )
         try:
             match modality:
                 case "RTSTRUCT" | "SEG":
@@ -493,7 +496,8 @@ class SampleInput(BaseModel):
                         RTStructureSet if modality == "RTSTRUCT" else SEG
                     )
                     vm = mask_klass.from_dicom(
-                        dicom=self.directory.parent / series.folder
+                        dicom=self.directory.parent / series.folder,
+                        metadata=series_info,  # pass along metadata
                     ).get_vector_mask(
                         reference_image=reference_image,
                         roi_matcher=self.roi_matcher,
@@ -567,6 +571,7 @@ if __name__ == "__main__":  # pragma: no cover
     medoutput = SampleOutput(
         directory=Path("temp_outputs/RADCURE_PROCESSED"),
         existing_file_mode=ExistingFileMode.OVERWRITE,
+        extra_context={"SampleNumber": "test"},
     )
     query_string = "CT,RTSTRUCT"
 

--- a/src/imgtools/io/sample_output.py
+++ b/src/imgtools/io/sample_output.py
@@ -46,12 +46,12 @@ class AnnotatedPathSequence(list):
         List of errors that occurred during the save process.
     """
 
-    errors: List[FailedToSaveSingleImageError | None]
+    errors: List[FailedToSaveSingleImageError] | None
 
     def __init__(
         self,
         paths: List[Path],
-        errors: List[FailedToSaveSingleImageError] = None,
+        errors: List[FailedToSaveSingleImageError] | None = None,
     ) -> None:
         """
         Initialize the annotated path sequence.

--- a/src/imgtools/io/sample_output.py
+++ b/src/imgtools/io/sample_output.py
@@ -223,10 +223,11 @@ class SampleOutput(BaseModel):
                     logger.error(errmsg)
                     raise TypeError(errmsg)
             except Exception as e:
-                errmsg = f"Failed to save image SeriesUID: {image.metadata.get('SeriesInstanceUID', 'unknown')}: {e}"
+                errmsg = f"Failed to save image SeriesUID: {image.metadata['SeriesInstanceUID']}: {e}"
 
                 # create an error object
                 save_error = FailedToSaveSingleImageError(errmsg, image)
                 save_errors.append(save_error)
+                logger.error(errmsg, error=save_error)
 
         return AnnotatedPathSequence(saved_files, save_errors)

--- a/src/imgtools/io/writers/abstract_base_writer.py
+++ b/src/imgtools/io/writers/abstract_base_writer.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
-import csv
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -11,9 +10,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
-    NoReturn,
     Optional,
-    Sequence,
     TypeVar,
     Generic,
 )
@@ -26,6 +23,7 @@ from imgtools.pattern_parser import (
     PatternResolver,
     MissingPlaceholderValueError,
 )
+from imgtools.utils import sanitize_file_name
 from imgtools.io.writers.index_writer import (
     IndexWriter,
     IndexSchemaMismatchError,
@@ -279,7 +277,7 @@ class AbstractBaseWriter(ABC, Generic[ContentType]):
                 key=e.key,
             ) from e
         if self.sanitize_filenames:
-            filename = self._sanitize_filename(filename)
+            filename = sanitize_file_name(filename)
         out_path = self.root_directory / filename
         # logger.debug(
         #     f"Resolved path: {out_path} and {out_path.exists()=}",
@@ -489,33 +487,6 @@ class AbstractBaseWriter(ABC, Generic[ContentType]):
         ):
             logger.debug(f"Deleting empty directory {self.root_directory}")
             self.root_directory.rmdir()  # remove the directory if it's empty
-
-    @staticmethod
-    def _sanitize_filename(filename: str) -> str:
-        """
-        Sanitize a filename to remove or replace bad characters.
-
-        Parameters
-        ----------
-        filename : str
-            The original filename.
-
-        Returns
-        -------
-        str
-            A sanitized filename safe for most file systems.
-        """
-
-        # Replace bad characters with underscores
-        sanitized = re.sub(r'[<>:"\\?*]', "_", filename)
-
-        # replace spaces with underscores
-        sanitized = re.sub(r"\s+", "_", sanitized)
-
-        # Optionally trim leading/trailing spaces or periods
-        sanitized = sanitized.strip(" .")
-
-        return sanitized
 
     def _ensure_directory_exists(self, directory: Path) -> None:
         """

--- a/src/imgtools/io/writers/abstract_base_writer.py
+++ b/src/imgtools/io/writers/abstract_base_writer.py
@@ -263,7 +263,7 @@ class AbstractBaseWriter(ABC, Generic[ContentType]):
             **self.context,
             **kwargs,
             "saved_time": datetime.now(timezone.utc).strftime(
-                "%Y-%m-%d:%H-%M-%S"
+                "%Y-%m-%d:%H:%M:%S"
             ),
         }
         self.set_context(**save_context)

--- a/src/imgtools/utils/sanitize_file_name.py
+++ b/src/imgtools/utils/sanitize_file_name.py
@@ -57,6 +57,9 @@ def sanitize_file_name(filename: str) -> str:
 
     # Replace disallowed characters elsewhere with underscores
     sanitized_name = disallowed_characters_pattern.sub("_", filename)
+    # if there is a " - " in the filename, replace it with just "-"
+    sanitized_name = sanitized_name.replace(" - ", "-")
+
     sanitized_name = sanitized_name.replace(" ", "_")
     sanitized_name = re.sub(r"(_{2,})", "_", sanitized_name)
     return sanitized_name

--- a/src/imgtools/utils/sanitize_file_name.py
+++ b/src/imgtools/utils/sanitize_file_name.py
@@ -13,15 +13,18 @@ Sanitize a filename:
 
 import re
 
+# Disallowed characters (excluding `/`)
+DISALLOWED_CHARS = r'<>:"\\|?*\x00-\x1f'
+DISALLOWED_CHARS_PATTERN = re.compile(f"[{DISALLOWED_CHARS}]")
+DISALLOWED_CHARS_STRIP_REGEX = re.compile(
+    f"^[{DISALLOWED_CHARS}]+|[{DISALLOWED_CHARS}]+$"
+)
+
 
 def sanitize_file_name(filename: str) -> str:
     """
-    Sanitize the file name by removing potentially dangerous characters at the
-    beginning and end of the filename, and replacing them elsewhere.
-
-    Removes disallowed characters at the beginning and end of the filename,
-    replaces disallowed characters with underscores, converts spaces to
-    underscores, and removes subsequent underscores.
+    Sanitize the file name by removing or replacing disallowed characters,
+    while preserving forward slashes.
 
     Parameters
     ----------
@@ -32,34 +35,21 @@ def sanitize_file_name(filename: str) -> str:
     -------
     str
         The sanitized file name.
-
-    Examples
-    --------
-    >>> sanitize_file_name("test<>file:/name.dcm")
-    'test_file_name.dcm'
-    >>> sanitize_file_name("my file name.dcm")
-    'my_file_name.dcm'
-    >>> sanitize_file_name("<bad>name.dcm")
-    'bad_name.dcm'
     """
-    assert filename is not None and filename != ""
-    assert isinstance(filename, str)
+    assert filename and isinstance(filename, str)
 
-    disallowed_characters_pattern = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+    # Remove disallowed characters at the start and end
+    filename = DISALLOWED_CHARS_STRIP_REGEX.sub("", filename).strip()
 
-    # Remove disallowed characters at the beginning and end
-    filename = re.sub(
-        r'^[<>:"/\\|?*\x00-\x1f]+|[<>:"/\\|?*\x00-\x1f]+$', "", filename
-    )
+    filename = filename.replace(" - ", "-")
 
-    # Remove spaces at the beginning and end
-    filename = filename.strip()
+    # Replace multiple spaces with a single space
+    filename = re.sub(r"\s+", "_", filename)
 
-    # Replace disallowed characters elsewhere with underscores
-    sanitized_name = disallowed_characters_pattern.sub("_", filename)
-    # if there is a " - " in the filename, replace it with just "-"
-    sanitized_name = sanitized_name.replace(" - ", "-")
+    # Replace multiple consecutive disallowed characters with a single underscore
+    filename = re.sub(f"[{DISALLOWED_CHARS}]+", "_", filename)
 
-    sanitized_name = sanitized_name.replace(" ", "_")
-    sanitized_name = re.sub(r"(_{2,})", "_", sanitized_name)
-    return sanitized_name
+    # Replace remaining disallowed characters with underscores
+    sanitized = DISALLOWED_CHARS_PATTERN.sub("_", filename)
+
+    return sanitized

--- a/tests/unittests/utilities/test_sanitize.py
+++ b/tests/unittests/utilities/test_sanitize.py
@@ -1,73 +1,98 @@
 import pytest
-from imgtools.utils import sanitize_file_name  # Adjust the import based on your module name
+from imgtools.utils import sanitize_file_name
 
 
 class TestSanitizeFileName:
-    def test_valid_filename_no_changes(self):
-        """Test that a valid filename remains unchanged."""
+    """Test suite for the sanitize_file_name function."""
+
+    def test_basic_valid_filenames(self):
+        """Test that valid filenames remain unchanged - basic cases with various extensions."""
         assert sanitize_file_name("valid_filename.dcm") == "valid_filename.dcm"
+        assert sanitize_file_name("file-name.txt") == "file-name.txt"
+        assert sanitize_file_name("simple_file_name.py") == "simple_file_name.py"
+        assert sanitize_file_name("MiXeD_CaSe.TXT") == "MiXeD_CaSe.TXT"
+        assert sanitize_file_name("UPPERCASE.txt") == "UPPERCASE.txt"
+        assert sanitize_file_name("lowercase.TXT") == "lowercase.TXT"
 
-    def test_disallowed_characters(self):
-        """Test that disallowed characters are replaced with underscores."""
-        assert sanitize_file_name("file<>name:/test?.dcm") == "file_name_test_.dcm"
+    def test_disallowed_characters_replacement(self):
+        """Test that disallowed characters are properly replaced with underscores."""
+        assert sanitize_file_name("file<>name:test?.dcm") == "file_name_test_.dcm"
+        assert sanitize_file_name("file:name.txt") == "file_name.txt"
+        assert sanitize_file_name("file*name?.txt") == "file_name_.txt"
+        assert sanitize_file_name("a<b>c:d\"e\\f|g?h*i") == "a_b_c_d_e_f_g_h_i"
+        assert sanitize_file_name("file::::name.txt") == "file_name.txt"
 
-    def test_spaces_replacement(self):
-        """Test that spaces are replaced with underscores."""
+    def test_whitespace_handling(self):
+        """Test handling of spaces and whitespace formatting in filenames."""
+        # Simple space replacement
         assert sanitize_file_name("my file name.dcm") == "my_file_name.dcm"
-
-    def test_multiple_underscores(self):
-        """Test that multiple consecutive underscores are replaced with a single underscore."""
-        assert sanitize_file_name("file<>name  test:/??.dcm") == "file_name_test_.dcm"
-
-    def test_empty_string(self):
-        """Test that an empty string raises an assertion error."""
-        with pytest.raises(AssertionError):
-            sanitize_file_name("")
-
-    def test_non_string_input(self):
-        """Test that non-string inputs raise an assertion error."""
-        with pytest.raises(AssertionError):
-            sanitize_file_name(None)
-        with pytest.raises(AssertionError):
-            sanitize_file_name(123)
-        with pytest.raises(AssertionError):
-            sanitize_file_name(["file_name.dcm"])
-
-    def test_control_characters(self):
-        """Test that control characters are removed."""
-        assert sanitize_file_name("file\x00\x1fname.dcm") == "file_name.dcm"
-
-    def test_edge_case_long_string(self):
-        """Test a long filename to ensure it sanitizes correctly."""
-        long_filename = "a" * 255 + "<>:\"/\\|?*.dcm"
-        expected = "a" * 255 + "_.dcm"
-        assert sanitize_file_name(long_filename) == expected
-
-    def test_edge_case_trailing_underscore(self):
-        """Test that sanitized filenames don't end with unnecessary underscores."""
-        assert sanitize_file_name("file<>:name?/") == "file_name"
-
-    def test_special_characters_with_spaces(self):
-        """Test a mix of special characters and spaces."""
-        assert sanitize_file_name("my file<>name:/ test?.dcm") == "my_file_name_test_.dcm"
-
-    def test_no_extension(self):
-        """Test filenames without extensions."""
-        assert sanitize_file_name("file<>name:/test") == "file_name_test"
-
-    def test_only_special_characters(self):
-        """Test filenames that consist only of disallowed characters."""
-        assert sanitize_file_name("<>:/filename\\|?*") == "filename"
-
-    def test_leading_trailing_spaces(self):
-        """Test filenames with leading and trailing spaces."""
-        assert sanitize_file_name("  my file name  .dcm") == "my_file_name_.dcm"
-
-    def test_hyphen_with_spaces(self):
-        """Test that ' - ' in filenames is replaced with '-'."""
+        assert sanitize_file_name("file with spaces.txt") == "file_with_spaces.txt"
+        # Padded spaces
+        assert sanitize_file_name("   padded   filename.txt") == "padded_filename.txt"
+        # Hyphen with spaces
         assert sanitize_file_name("file - name.dcm") == "file-name.dcm"
         assert sanitize_file_name("file - name - test.dcm") == "file-name-test.dcm"
         assert sanitize_file_name("file -name.dcm") == "file_-name.dcm"  # Single space not replaced
         assert sanitize_file_name("file- name.dcm") == "file-_name.dcm"  # Single space not replaced
         assert sanitize_file_name('UTERUS - 1 - SE') == 'UTERUS-1-SE'
-        assert sanitize_file_name(('UTERUS - 2')) == 'UTERUS-2'
+        assert sanitize_file_name('UTERUS - 2') == 'UTERUS-2'
+        # Multiple spaces and special chars
+        assert sanitize_file_name("  file   -  name.txt") == "file_-_name.txt"
+
+    def test_input_validation(self):
+        """Test input validation - empty strings and non-string inputs should raise AssertionError."""
+        with pytest.raises(AssertionError):
+            sanitize_file_name("")
+        
+        with pytest.raises(AssertionError):
+            sanitize_file_name(None)
+            
+        with pytest.raises(AssertionError):
+            sanitize_file_name(123)
+            
+        with pytest.raises(AssertionError):
+            sanitize_file_name(["file_name.dcm"])
+
+    def test_path_handling(self):
+        """Test handling of path-like filenames where forward slashes should be preserved."""
+        assert sanitize_file_name("path/to/file.txt") == "path/to/file.txt"
+        assert sanitize_file_name("/root/path/file.txt") == "/root/path/file.txt"
+        assert sanitize_file_name("path/with:<>|?*/issues.txt") == "path/with_/issues.txt"
+        # Test consecutive slashes
+        assert sanitize_file_name("path///to////file.txt") == "path///to////file.txt"
+
+    def test_unicode_and_special_characters(self):
+        """Test handling of unicode, control characters, and other special characters."""
+        # Unicode characters
+        assert sanitize_file_name("résumé.pdf") == "résumé.pdf"
+        assert sanitize_file_name("文件名.txt") == "文件名.txt"
+        assert sanitize_file_name("üñîçódè<>*:?.txt") == "üñîçódè_.txt"
+        
+        # Control characters (0x00-0x1f)
+        assert sanitize_file_name("file\x01name\x1F.txt") == "file_name_.txt"
+        assert sanitize_file_name("\x00\x01\x02file.txt") == "file.txt"
+        assert sanitize_file_name("file.txt\x1d\x1e\x1f") == "file.txt"
+        
+    def test_edge_cases(self):
+        """Test edge cases including leading/trailing characters, complex patterns, and extreme cases."""
+        # Leading and trailing characters
+        assert sanitize_file_name("...file.txt") == "...file.txt"
+        assert sanitize_file_name("file.txt...") == "file.txt..."
+        assert sanitize_file_name(">>file.txt<<") == "file.txt"
+        assert sanitize_file_name("   <>:?*|   valid.txt   ") == "__valid.txt"
+        
+        # Multiple periods
+        assert sanitize_file_name("file.name.with.dots.txt") == "file.name.with.dots.txt"
+        assert sanitize_file_name("..hidden.file") == "..hidden.file"
+        assert sanitize_file_name("file....name") == "file....name"
+        
+        # All disallowed characters
+        assert sanitize_file_name("<>|?*:\\\"") == ""
+        assert sanitize_file_name("<>file<>") == "file"
+        
+        # Very long filename
+        long_name = "a" * 1000
+        assert sanitize_file_name(long_name) == long_name
+        
+        # File with extension but only disallowed characters in name
+        assert sanitize_file_name("<>:|?*.txt") == ".txt"

--- a/tests/unittests/utilities/test_sanitize.py
+++ b/tests/unittests/utilities/test_sanitize.py
@@ -62,3 +62,12 @@ class TestSanitizeFileName:
     def test_leading_trailing_spaces(self):
         """Test filenames with leading and trailing spaces."""
         assert sanitize_file_name("  my file name  .dcm") == "my_file_name_.dcm"
+
+    def test_hyphen_with_spaces(self):
+        """Test that ' - ' in filenames is replaced with '-'."""
+        assert sanitize_file_name("file - name.dcm") == "file-name.dcm"
+        assert sanitize_file_name("file - name - test.dcm") == "file-name-test.dcm"
+        assert sanitize_file_name("file -name.dcm") == "file_-name.dcm"  # Single space not replaced
+        assert sanitize_file_name("file- name.dcm") == "file-_name.dcm"  # Single space not replaced
+        assert sanitize_file_name('UTERUS - 1 - SE') == 'UTERUS-1-SE'
+        assert sanitize_file_name(('UTERUS - 2')) == 'UTERUS-2'


### PR DESCRIPTION
- Update the package lock file to reflect new versions. 
- Add validation for `ContourGeometricType` in `RTStructureSet`, 

- enhance `SampleOutput` to return an `AnnotatedPathSequence` with error handling,

- improve error handling in `process_one_sample` to log errors while allowing processing to continue.


### TODO

- [ ] write tests
- [ ] the whole `ProcessSampleResult` stuff now is suuuuper messy, the whole error/success tracking stuff needs to be cleaned up, and logic of errors and stuff need to be very clear
- [x] mypy errors due to invariants 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved error handling and reporting when saving image outputs, with detailed feedback on any images that failed to save.
- **Bug Fixes**
	- Enhanced validation for geometric types in DICOM contour data, providing clearer error messages for unexpected formats.
	- Adjusted processing logic to continue despite partial input mismatches and added checks for output file saving.
- **Other**
	- Updated example usage for extracting ROI names from DICOM files in the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->