### PR TITLE
fix: Build-docs references main now instead of development

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,7 +140,7 @@ jobs:
     ################################################################################################
     Publish-Docs:
         needs: Build-Docs
-        if: github.ref == 'refs/heads/development'
+        if: github.ref == 'refs/heads/main'
 
         concurrency:
             group: ${{ github.workflow }}-${{ github.ref }}

--- a/pixi.lock
+++ b/pixi.lock
@@ -11256,8 +11256,8 @@ packages:
   timestamp: 1733255681319
 - pypi: ./
   name: med-imagetools
-  version: 2.9.0
-  sha256: 097840c4219dd2a4ed0269a4632bab2560fc792cae48ede1a940346c6a150eda
+  version: 2.9.1
+  sha256: 7308b419e30346a74eb3dab3bd5aac1141c30f61f848c53198276e80747c1368
   requires_dist:
   - structlog>=25.0,<26
   - click>=8.1,<9


### PR DESCRIPTION
Addresses  Issue https://github.com/bhklab/med-imagetools/issues/382