### PR TITLE
feat: expose group_by_root parameter in Autopipeline and SampleInput.…

### DIFF
--- a/src/imgtools/autopipeline.py
+++ b/src/imgtools/autopipeline.py
@@ -306,6 +306,7 @@ class Autopipeline:
         spacing: tuple[float, float, float] = (0.0, 0.0, 0.0),
         window: float | None = None,
         level: float | None = None,
+        group_by_root: bool = True,
     ) -> None:
         """
         Initialize the Autopipeline.
@@ -343,6 +344,9 @@ class Autopipeline:
             Window level for intensity normalization, by default None
         level : float | None, optional
             Window level for intensity normalization, by default None
+        group_by_root : bool, default=True
+            If True, group results by their root CT/MR/PT node (avoids duplicate
+            root nodes). Set to False to get all matching series individually.
         """
         self.input = SampleInput.build(
             directory=Path(input_directory),
@@ -382,6 +386,7 @@ class Autopipeline:
             transforms.append(WindowIntensity(window=window, level=level))
 
         self.transformer = Transformer(transforms)
+        self.group_by_root = group_by_root
 
         logger.info("Pipeline initialized")
 
@@ -399,7 +404,7 @@ class Autopipeline:
         """
 
         # Load the samples
-        samples = self.input.query()
+        samples = self.input.query(group_by_root=self.group_by_root)
         samples = sorted(samples, key=lambda x: x[0].PatientID.lower())
 
         if not samples:

--- a/src/imgtools/io/sample_input.py
+++ b/src/imgtools/io/sample_input.py
@@ -291,7 +291,17 @@ class SampleInput(BaseModel):
         modalities: str | None = None,
         group_by_root: bool = True,
     ) -> list[list[SeriesNode]]:
-        """Query the interlacer for a specific modality."""
+        """Query the interlacer for specific modalities.
+
+        Parameters
+        ----------
+        modalities : str | None, optional
+            Comma-separated modality query string. If None, uses configured
+            modalities or "*" when no modalities are configured.
+        group_by_root : bool, default=True
+            If True, group matched series by root CT/MR/PT node. If False,
+            return all matching paths without root-level grouping.
+        """
         if modalities is None:
             modalities = ",".join(self.modalities) if self.modalities else "*"
         return self.interlacer.query(modalities, group_by_root=group_by_root)

--- a/src/imgtools/io/sample_input.py
+++ b/src/imgtools/io/sample_input.py
@@ -286,11 +286,15 @@ class SampleInput(BaseModel):
     def print_tree(self) -> None:
         self.interlacer.print_tree(input_directory=self.directory)
 
-    def query(self, modalities: str | None = None) -> list[list[SeriesNode]]:
+    def query(
+        self,
+        modalities: str | None = None,
+        group_by_root: bool = True,
+    ) -> list[list[SeriesNode]]:
         """Query the interlacer for a specific modality."""
         if modalities is None:
             modalities = ",".join(self.modalities) if self.modalities else "*"
-        return self.interlacer.query(modalities)
+        return self.interlacer.query(modalities, group_by_root=group_by_root)
 
     ###################################################################
     # Loading methods


### PR DESCRIPTION
Threads the existing Interlacer.query group_by_root flag up through SampleInput.query and Autopipeline.__init__/run so callers can disable root-grouping behaviour. Defaults to True to preserve existing behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `group_by_root` parameter (defaults to `True`) to configure sample grouping behavior during pipeline execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bhklab/med-imagetools/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->