### PR TITLE
Finished feature for test_set_split

### DIFF
--- a/src/imgtools/cli/nnunet_pipeline.py
+++ b/src/imgtools/cli/nnunet_pipeline.py
@@ -123,6 +123,15 @@ existing_file_modes = ["overwrite", "skip", "fail"]
     show_default=True,  
     help="Allow one ROI to match multiple keys in the match map"  
 )
+@click.option(
+    "--test-set-ratio",
+    type=click.FloatRange(0.0,1.0),
+    default=0.0,
+    help="The proportion of valid images that are to be used in the test set.",
+    show_default=True
+)
+
+
 @click.help_option(
     "-h",
     "--help",
@@ -142,6 +151,7 @@ def nnunet_pipeline(
     level: float,
     roi_ignore_case: bool,
     roi_allow_multi_matches: bool,
+    test_set_ratio:float
 ) -> None:
     """Process medical images in nnUNet format.
     
@@ -199,6 +209,7 @@ def nnunet_pipeline(
         spacing=spacing,
         window=window,
         level=level,
+        test_set_ratio=test_set_ratio
     )
     
     # Run the pipeline

--- a/src/imgtools/io/nnunet_output.py
+++ b/src/imgtools/io/nnunet_output.py
@@ -4,7 +4,7 @@ import contextlib
 from enum import Enum
 from math import ceil
 from pathlib import Path
-from random import sample as random_sample
+import random
 from shutil import move
 from typing import Any, Dict, Sequence,List
 
@@ -289,7 +289,7 @@ class nnUNetOutput(BaseModel):  # noqa: N801
         output_folder_path.mkdir(exist_ok=True, parents=True)
         move(file_path, target_path)
 
-    def split_dataset(self, test_set_ratio: float, successful_results: List[ProcessSampleResult]) -> None:
+    def split_dataset(self, test_set_ratio: float, successful_results: List[ProcessSampleResult], RANDOM_SEED=42) -> None:
         """
         Splits a dataset into a training and test set. 
         Assumes that the files have already been processed and saved to imagesTr and labelsTr dirs.
@@ -310,8 +310,8 @@ class nnUNetOutput(BaseModel):  # noqa: N801
 
         dir_map = {'labelsTr': 'labelsTs', 'imagesTr': 'imagesTs'}
 
-        success_count = len(successful_results)
-        test_set = random_sample(successful_results, ceil(test_set_ratio * success_count))
+        rng = random.Random(RANDOM_SEED)
+        test_set = rng.sample(successful_results, ceil(test_set_ratio * success_count))
 
         for sample in test_set:
             for path in sample.output_files:

--- a/src/imgtools/io/nnunet_output.py
+++ b/src/imgtools/io/nnunet_output.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import contextlib
 from enum import Enum
+from math import ceil
 from pathlib import Path
-from typing import Any, Dict, Sequence
+from random import sample as random_sample
+from shutil import move
+from typing import Any, Dict, Sequence,List
 
 import pandas as pd
 from pydantic import (
@@ -13,6 +16,7 @@ from pydantic import (
     field_validator,
 )
 
+from imgtools.autopipeline import ProcessSampleResult
 from imgtools.coretypes import MedImage, Scan, VectorMask
 from imgtools.io.validators import validate_directory
 from imgtools.io.writers import (
@@ -260,6 +264,58 @@ class nnUNetOutput(BaseModel):  # noqa: N801
             )
 
         return valid_masks
+    
+    def _move_file_to_test_split(self, file_path: Path, dir_map: dict[str, str]):
+        """
+        Calculates the Ts path and moves the file based on the provided directory map.
+        Parameters
+        ----------
+        file_path: Path
+            The path to the file that is to be moved
+        dir_map: dict[str, str]
+            A dictionary whose keys are the name of the source dir, and values are the names of the value dirs 
+        
+        Returns
+        -------
+        Nothing
+        """
+        
+        if file_path.parent.name not in dir_map:
+            raise ValueError(f"Unexpected parent directory for split: {file_path.parent.name}")
+            
+        # 1. Construct the new path, NOTE: nnUNet requires everything in images type dir to be a file.
+        output_folder_path = file_path.parent.parent / dir_map[file_path.parent.name]
+        target_path =  output_folder_path/ file_path.name
+        output_folder_path.mkdir(exist_ok=True, parents=True)
+        move(file_path, target_path)
+
+    def split_dataset(self, test_set_ratio: float, successful_results: List[ProcessSampleResult]) -> None:
+        """
+        Splits a dataset into a training and test set. 
+        Assumes that the files have already been processed and saved to imagesTr and labelsTr dirs.
+        Parameters
+        ----------
+        test_set_ratio: float
+            The proportion of the processed images that are to be used in the test set
+        successful_results: List[ProcessSampleResult]
+            List of the processed results objects for successfully processed images. 
+        
+        Returns
+        -------
+        Nothing
+
+        """
+        if not successful_results:
+            return
+
+        dir_map = {'labelsTr': 'labelsTs', 'imagesTr': 'imagesTs'}
+
+        success_count = len(successful_results)
+        test_set = random_sample(successful_results, ceil(test_set_ratio * success_count))
+
+        for sample in test_set:
+            for path in sample.output_files:
+                self._move_file_to_test_split(path, dir_map) 
 
     def finalize_dataset(self) -> None:
         """Finalize dataset by generating preprocessing scripts and dataset JSON configuration."""

--- a/src/imgtools/nnunet_pipeline.py
+++ b/src/imgtools/nnunet_pipeline.py
@@ -54,6 +54,7 @@ class nnUNetPipeline:  # noqa: N801
         spacing: tuple[float, float, float] = (0.0, 0.0, 0.0),
         window: float | None = None,
         level: float | None = None,
+        test_set_ratio: float = 0.0
     ) -> None:
         """
         Initialize the nnUNetpipeline.
@@ -86,6 +87,8 @@ class nnUNetPipeline:  # noqa: N801
             Window level for intensity normalization, by default None
         level : float | None, optional
             Window level for intensity normalization, by default None
+        test_set_ratio : float 
+            The proportion of samples in the dataset that is to be used for testing
         """
 
         # Validate modalities
@@ -143,9 +146,15 @@ class nnUNetPipeline:  # noqa: N801
             transforms.append(WindowIntensity(window=window, level=level))
 
         self.transformer = Transformer(transforms)
+        
+        if test_set_ratio < 0:
+            raise ValueError("The test_set_ratio must be greater than or equal to 0")
 
+        self.test_set_ratio = min(test_set_ratio, 1)
+        
         logger.info("Pipeline initialized")
-
+    
+    #TODO: This function is long and has a lot of concerns built into it.
     def run(
         self,
     ) -> Dict[str, List[ProcessSampleResult]]:
@@ -208,10 +217,13 @@ class nnUNetPipeline:  # noqa: N801
                     failed_results.append(result)
                     pbar.update(0)
 
+
         # Log summary information
         success_count = len(successful_results)
         failure_count = len(failed_results)
         total_count = len(all_results)
+
+        self.output.split_dataset(self.test_set_ratio, successful_results)
 
         logger.info(
             f"Processing complete. {success_count} successful, {failure_count} failed "


### PR DESCRIPTION
Hi sorry issue took a little while, but I wrote up a minimal way of implementing a test_set_split for nnunet-pipeline.

The feature takes the successfully processed images and moves a proportion of the images/labels to the appropriate dirs in the output dir. I could not find any tests for nnunet-pipeline but this should probably be added to them when they're ready. There is CLI support for the feature as well as hints. Please let me know if there's anything II should change style wise.


Fixes #443



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `test-set-ratio` option to the command-line workflow, letting you split a portion of successfully processed data into a test set.
  * The pipeline now automatically moves the selected files into the appropriate test folders after processing.

* **Bug Fixes**
  * Added validation for the new ratio value to keep it within a valid range and prevent invalid dataset splits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->